### PR TITLE
Random perf improvements

### DIFF
--- a/src/Markdig.Tests/TestMarkdigCoreApi.cs
+++ b/src/Markdig.Tests/TestMarkdigCoreApi.cs
@@ -11,11 +11,17 @@ namespace Markdig.Tests
         [Test]
         public void TestToHtml()
         {
-            string html = Markdown.ToHtml("This is a text with some *emphasis*");
-            Assert.AreEqual("<p>This is a text with some <em>emphasis</em></p>\n", html);
+            for (int i = 0; i < 5; i++)
+            {
+                string html = Markdown.ToHtml("This is a text with some *emphasis*");
+                Assert.AreEqual("<p>This is a text with some <em>emphasis</em></p>\n", html);
+            }
 
-            html = Markdown.ToHtml("This is a text with a https://link.tld/");
-            Assert.AreNotEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
+            for (int i = 0; i < 5; i++)
+            {
+                string html = Markdown.ToHtml("This is a text with a https://link.tld/");
+                Assert.AreNotEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
+            }
         }
 
         [Test]
@@ -24,18 +30,24 @@ namespace Markdig.Tests
             var pipeline = new MarkdownPipelineBuilder()
                 .Build();
 
-            string html = Markdown.ToHtml("This is a text with some *emphasis*", pipeline);
-            Assert.AreEqual("<p>This is a text with some <em>emphasis</em></p>\n", html);
+            for (int i = 0; i < 5; i++)
+            {
+                string html = Markdown.ToHtml("This is a text with some *emphasis*", pipeline);
+                Assert.AreEqual("<p>This is a text with some <em>emphasis</em></p>\n", html);
 
-            html = Markdown.ToHtml("This is a text with a https://link.tld/", pipeline);
-            Assert.AreNotEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
+                html = Markdown.ToHtml("This is a text with a https://link.tld/", pipeline);
+                Assert.AreNotEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
+            }
 
             pipeline = new MarkdownPipelineBuilder()
                 .UseAdvancedExtensions()
                 .Build();
 
-            html = Markdown.ToHtml("This is a text with a https://link.tld/", pipeline);
-            Assert.AreEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
+            for (int i = 0; i < 5; i++)
+            {
+                string html = Markdown.ToHtml("This is a text with a https://link.tld/", pipeline);
+                Assert.AreEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
+            }
         }
 
         [Test]
@@ -43,19 +55,25 @@ namespace Markdig.Tests
         {
             StringWriter writer = new StringWriter();
 
-            _ = Markdown.ToHtml("This is a text with some *emphasis*", writer);
-            string html = writer.ToString();
-            Assert.AreEqual("<p>This is a text with some <em>emphasis</em></p>\n", html);
+            for (int i = 0; i < 5; i++)
+            {
+                _ = Markdown.ToHtml("This is a text with some *emphasis*", writer);
+                string html = writer.ToString();
+                Assert.AreEqual("<p>This is a text with some <em>emphasis</em></p>\n", html);
+                writer.GetStringBuilder().Length = 0;
+            }
 
-            writer = new StringWriter();
             var pipeline = new MarkdownPipelineBuilder()
                 .UseAdvancedExtensions()
                 .Build();
 
-            _ = Markdown.ToHtml("This is a text with a https://link.tld/", writer, pipeline);
-            html = writer.ToString();
-            Assert.AreEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
-
+            for (int i = 0; i < 5; i++)
+            {
+                _ = Markdown.ToHtml("This is a text with a https://link.tld/", writer, pipeline);
+                string html = writer.ToString();
+                Assert.AreEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
+                writer.GetStringBuilder().Length = 0;
+            }
         }
 
         [Test]
@@ -64,19 +82,26 @@ namespace Markdig.Tests
             StringWriter writer = new StringWriter();
             HtmlRenderer renderer = new HtmlRenderer(writer);
 
-            _ = Markdown.Convert("This is a text with some *emphasis*", renderer);
-            string html = writer.ToString();
-            Assert.AreEqual("<p>This is a text with some <em>emphasis</em></p>\n", html);
+            for (int i = 0; i < 5; i++)
+            {
+                _ = Markdown.Convert("This is a text with some *emphasis*", renderer);
+                string html = writer.ToString();
+                Assert.AreEqual("<p>This is a text with some <em>emphasis</em></p>\n", html);
+                writer.GetStringBuilder().Length = 0;
+            }
 
-            writer = new StringWriter();
             renderer = new HtmlRenderer(writer);
             var pipeline = new MarkdownPipelineBuilder()
                 .UseAdvancedExtensions()
                 .Build();
 
-            _ = Markdown.Convert("This is a text with a https://link.tld/", renderer, pipeline);
-            html = writer.ToString();
-            Assert.AreEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
+            for (int i = 0; i < 5; i++)
+            {
+                _ = Markdown.Convert("This is a text with a https://link.tld/", renderer, pipeline);
+                string html = writer.ToString();
+                Assert.AreEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
+                writer.GetStringBuilder().Length = 0;
+            }
         }
 
         [Test]
@@ -88,62 +113,76 @@ namespace Markdig.Tests
                 .UsePreciseSourceLocation()
                 .Build();
 
-            MarkdownDocument document = Markdown.Parse(markdown, pipeline);
+            for (int i = 0; i < 5; i++)
+            {
+                MarkdownDocument document = Markdown.Parse(markdown, pipeline);
 
-            Assert.AreEqual(1, document.LineCount);
-            Assert.AreEqual(markdown.Length, document.Span.Length);
-            Assert.AreEqual(1, document.LineStartIndexes.Count);
-            Assert.AreEqual(0, document.LineStartIndexes[0]);
+                Assert.AreEqual(1, document.LineCount);
+                Assert.AreEqual(markdown.Length, document.Span.Length);
+                Assert.AreEqual(1, document.LineStartIndexes.Count);
+                Assert.AreEqual(0, document.LineStartIndexes[0]);
 
-            Assert.AreEqual(1, document.Count);
-            ParagraphBlock paragraph = document[0] as ParagraphBlock;
-            Assert.NotNull(paragraph);
-            Assert.AreEqual(markdown.Length, paragraph.Span.Length);
-            LiteralInline literal = paragraph.Inline.FirstChild as LiteralInline;
-            Assert.NotNull(literal);
-            Assert.AreEqual("This is a text with some ", literal.ToString());
-            EmphasisInline emphasis = literal.NextSibling as EmphasisInline;
-            Assert.NotNull(emphasis);
-            Assert.AreEqual("*emphasis*".Length, emphasis.Span.Length);
-            LiteralInline emphasisLiteral = emphasis.FirstChild as LiteralInline;
-            Assert.NotNull(emphasisLiteral);
-            Assert.AreEqual("emphasis", emphasisLiteral.ToString());
-            Assert.Null(emphasisLiteral.NextSibling);
-            Assert.Null(emphasis.NextSibling);
+                Assert.AreEqual(1, document.Count);
+                ParagraphBlock paragraph = document[0] as ParagraphBlock;
+                Assert.NotNull(paragraph);
+                Assert.AreEqual(markdown.Length, paragraph.Span.Length);
+                LiteralInline literal = paragraph.Inline.FirstChild as LiteralInline;
+                Assert.NotNull(literal);
+                Assert.AreEqual("This is a text with some ", literal.ToString());
+                EmphasisInline emphasis = literal.NextSibling as EmphasisInline;
+                Assert.NotNull(emphasis);
+                Assert.AreEqual("*emphasis*".Length, emphasis.Span.Length);
+                LiteralInline emphasisLiteral = emphasis.FirstChild as LiteralInline;
+                Assert.NotNull(emphasisLiteral);
+                Assert.AreEqual("emphasis", emphasisLiteral.ToString());
+                Assert.Null(emphasisLiteral.NextSibling);
+                Assert.Null(emphasis.NextSibling);
+            }
         }
 
         [Test]
         public void TestNormalize()
         {
-            string normalized = Markdown.Normalize("Heading\n=======");
-            Assert.AreEqual("# Heading", normalized);
+            for (int i = 0; i < 5; i++)
+            {
+                string normalized = Markdown.Normalize("Heading\n=======");
+                Assert.AreEqual("# Heading", normalized);
+            }
         }
 
         [Test]
         public void TestNormalizeWithWriter()
         {
-            StringWriter writer = new StringWriter();
-
-            _ = Markdown.Normalize("Heading\n=======", writer);
-            string normalized = writer.ToString();
-            Assert.AreEqual("# Heading", normalized);
+            for (int i = 0; i < 5; i++)
+            {
+                StringWriter writer = new StringWriter();
+                _ = Markdown.Normalize("Heading\n=======", writer);
+                string normalized = writer.ToString();
+                Assert.AreEqual("# Heading", normalized);
+            }
         }
 
         [Test]
         public void TestToPlainText()
         {
-            string plainText = Markdown.ToPlainText("*Hello*, [world](http://example.com)!");
-            Assert.AreEqual("Hello, world!\n", plainText);
+            for (int i = 0; i < 5; i++)
+            {
+                string plainText = Markdown.ToPlainText("*Hello*, [world](http://example.com)!");
+                Assert.AreEqual("Hello, world!\n", plainText);
+            }
         }
 
         [Test]
         public void TestToPlainTextWithWriter()
         {
-            StringWriter writer = new StringWriter();
+            for (int i = 0; i < 5; i++)
+            {
+                StringWriter writer = new StringWriter();
 
-            _ = Markdown.ToPlainText("*Hello*, [world](http://example.com)!", writer);
-            string plainText = writer.ToString();
-            Assert.AreEqual("Hello, world!\n", plainText);
+                _ = Markdown.ToPlainText("*Hello*, [world](http://example.com)!", writer);
+                string plainText = writer.ToString();
+                Assert.AreEqual("Hello, world!\n", plainText);
+            }
         }
     }
 }

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
@@ -51,7 +51,7 @@ namespace Markdig.Extensions.Abbreviations
             {
                 return BlockState.None;
             }
-            slice.NextChar();
+            slice.SkipChar();
 
             slice.Trim();
 

--- a/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierExtension.cs
+++ b/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierExtension.cs
@@ -217,6 +217,7 @@ namespace Markdig.Extensions.AutoIdentifiers
             protected override void Reset(HtmlRenderer instance)
             {
                 instance.Reset();
+                ((StringWriter)instance.Writer).GetStringBuilder().Length = 0;
             }
         }
     }

--- a/src/Markdig/Extensions/GenericAttributes/GenericAttributesParser.cs
+++ b/src/Markdig/Extensions/GenericAttributes/GenericAttributesParser.cs
@@ -107,7 +107,7 @@ namespace Markdig.Extensions.GenericAttributes
                 if (c == '}')
                 {
                     isValid = true;
-                    line.NextChar(); // skip }
+                    line.SkipChar(); // skip }
                     break;
                 }
 
@@ -191,7 +191,7 @@ namespace Markdig.Extensions.GenericAttributes
                     }
 
                     // Go to next char, skip any spaces
-                    line.NextChar();
+                    line.SkipChar();
                     line.TrimStart();
 
                     int startValue = -1;

--- a/src/Markdig/Extensions/SmartyPants/SmartyPantsInlineParser.cs
+++ b/src/Markdig/Extensions/SmartyPants/SmartyPantsInlineParser.cs
@@ -52,7 +52,7 @@ namespace Markdig.Extensions.SmartyPants
                     type = SmartyPantType.Quote; // We will resolve them at the end of parsing all inlines
                     if (slice.PeekChar() == '\'')
                     {
-                        slice.NextChar();
+                        slice.SkipChar();
                         type = SmartyPantType.DoubleQuote; // We will resolve them at the end of parsing all inlines
                     }
                     break;

--- a/src/Markdig/Extensions/Tables/GridTableParser.cs
+++ b/src/Markdig/Extensions/Tables/GridTableParser.cs
@@ -33,7 +33,7 @@ namespace Markdig.Extensions.Tables
             while (c == '+')
             {
                 var columnStart = line.Start;
-                line.NextChar();
+                line.SkipChar();
                 line.TrimStart();
 
                 // if we have reached the end of the line, exit
@@ -161,15 +161,16 @@ namespace Markdig.Extensions.Tables
 
         private static bool IsRowSeperator(StringSlice slice)
         {
-            while (slice.Length > 0)
+            char c = slice.CurrentChar;
+            do
             {
-                if (slice.CurrentChar != '-' && slice.CurrentChar != '=' && slice.CurrentChar != ':')
+                if (c != '-' && c != '=' && c != ':')
                 {
-                    return false;
+                    return c == '\0';
                 }
-                slice.NextChar();
+                c = slice.NextChar();
             }
-            return true;
+            while (true);
         }
 
         private static void TerminateCurrentRow(BlockProcessor processor, GridTableState tableState, Table gridTable, bool isLastRow)

--- a/src/Markdig/Extensions/Tables/PipeTableParser.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableParser.cs
@@ -112,7 +112,7 @@ namespace Markdig.Extensions.Tables
                 }
                 tableState.LineHasPipe = true;
                 tableState.LineIndex = localLineIndex;
-                slice.NextChar(); // Skip the `|` character
+                slice.SkipChar(); // Skip the `|` character
 
                 tableState.ColumnAndLineDelimiters.Add(processor.Inline);
             }

--- a/src/Markdig/Extensions/Tables/TableHelper.cs
+++ b/src/Markdig/Extensions/Tables/TableHelper.cs
@@ -60,7 +60,7 @@ namespace Markdig.Extensions.Tables
             if (c == ':')
             {
                 hasLeft = true;
-                slice.NextChar();
+                slice.SkipChar();
             }
 
             slice.TrimStart();
@@ -91,7 +91,7 @@ namespace Markdig.Extensions.Tables
             if (c == ':')
             {
                 hasRight = true;
-                slice.NextChar();
+                slice.SkipChar();
             }
             slice.TrimStart();
 

--- a/src/Markdig/Extensions/TaskLists/TaskListInlineParser.cs
+++ b/src/Markdig/Extensions/TaskLists/TaskListInlineParser.cs
@@ -56,7 +56,7 @@ namespace Markdig.Extensions.TaskLists
                 return false;
             }
             // Skip last ]
-            slice.NextChar();
+            slice.SkipChar();
 
             // Create the TaskList
             var taskItem = new TaskList()

--- a/src/Markdig/Helpers/HtmlHelper.cs
+++ b/src/Markdig/Helpers/HtmlHelper.cs
@@ -127,7 +127,7 @@ namespace Markdig.Helpers
                     case '\0':
                         return false;
                     case '>':
-                        text.NextChar();
+                        text.SkipChar();
                         builder.Append(c);
                         return true;
                     case '/':
@@ -137,7 +137,7 @@ namespace Markdig.Helpers
                         {
                             return false;
                         }
-                        text.NextChar();
+                        text.SkipChar();
                         builder.Append('>');
                         return true;
                     case '=':
@@ -269,7 +269,7 @@ namespace Markdig.Helpers
 
                 if (c == '>')
                 {
-                    text.NextChar();
+                    text.SkipChar();
                     builder.Append('>');
                     return true;
                 }
@@ -304,7 +304,7 @@ namespace Markdig.Helpers
                         if (c == '>')
                         {
                             builder.Append('>');
-                            text.NextChar();
+                            text.SkipChar();
                             return true;
                         }
 
@@ -337,7 +337,7 @@ namespace Markdig.Helpers
                 c = text.NextChar();
                 if (c == '>')
                 {
-                    text.NextChar();
+                    text.SkipChar();
                     builder.Append('>');
                     return true;
                 }
@@ -392,7 +392,7 @@ namespace Markdig.Helpers
                     if (c == '>')
                     {
                         builder.Append('>');
-                        text.NextChar();
+                        text.SkipChar();
                         return true;
                     }
                     return false;
@@ -417,7 +417,7 @@ namespace Markdig.Helpers
                 if (c == '>' && prevChar == '?')
                 {
                     builder.Append('>');
-                    text.NextChar();
+                    text.SkipChar();
                     return true;
                 }
                 prevChar = c;
@@ -532,7 +532,7 @@ namespace Markdig.Helpers
                 c = slice.PeekChar();
                 if (c == 'x' || c == 'X')
                 {
-                    c = slice.NextChar(); // skip #
+                    slice.SkipChar(); // skip #
                     // expect 1-6 hex digits starting from pos+3
                     while (c != '\0')
                     {

--- a/src/Markdig/Helpers/ICharIterator.cs
+++ b/src/Markdig/Helpers/ICharIterator.cs
@@ -32,11 +32,22 @@ namespace Markdig.Helpers
         char NextChar();
 
         /// <summary>
+        /// Goes to the next character, incrementing the <see cref="Start" /> position.
+        /// </summary>
+        void SkipChar();
+
+        /// <summary>
+        /// Peeks at the next character, without incrementing the <see cref="Start"/> position.
+        /// </summary>
+        /// <returns>The next character. `\0` is end of the iteration.</returns>
+        char PeekChar();
+
+        /// <summary>
         /// Peeks at the next character, without incrementing the <see cref="Start"/> position.
         /// </summary>
         /// <param name="offset"></param>
         /// <returns>The next character. `\0` is end of the iteration.</returns>
-        char PeekChar(int offset = 1);
+        char PeekChar(int offset);
 
         /// <summary>
         /// Gets a value indicating whether this instance is empty.

--- a/src/Markdig/Helpers/LinkHelper.cs
+++ b/src/Markdig/Helpers/LinkHelper.cs
@@ -246,7 +246,7 @@ namespace Markdig.Helpers
                             break;
                         }
 
-                        text.NextChar();
+                        text.SkipChar();
                         link = builder.ToString();
                         builder.Length = 0;
                         return true;
@@ -294,7 +294,7 @@ namespace Markdig.Helpers
 
                     if (c == '>')
                     {
-                        text.NextChar();
+                        text.SkipChar();
                         link = builder.ToString();
                         builder.Length = 0;
                         return true;
@@ -355,7 +355,7 @@ namespace Markdig.Helpers
             // 1. An inline link consists of a link text followed immediately by a left parenthesis (, 
             if (c == '(')
             {
-                text.NextChar();
+                text.SkipChar();
                 text.TrimStart();
 
                 var pos = text.Start;
@@ -407,7 +407,7 @@ namespace Markdig.Helpers
             if (isValid)
             {
                 // Skip ')'
-                text.NextChar();
+                text.SkipChar();
                 title ??= string.Empty;
             }
 
@@ -466,7 +466,7 @@ namespace Markdig.Helpers
                         }
 
                         // Skip last quote
-                        text.NextChar();
+                        text.SkipChar();
                         isValid = true;
                         break;
                     }
@@ -527,7 +527,7 @@ namespace Markdig.Helpers
                     c = text.NextChar();
                     if (!hasEscape && c == '>')
                     {
-                        text.NextChar();
+                        text.SkipChar();
                         isValid = true;
                         break;
                     }
@@ -743,7 +743,7 @@ namespace Markdig.Helpers
                 label = null;
                 return false;
             }
-            text.NextChar(); // Skip ':'
+            text.SkipChar(); // Skip ':'
 
             // Skip any whitespace before the url
             text.TrimStart();
@@ -873,7 +873,7 @@ namespace Markdig.Helpers
 
                     if (c == ']')
                     {
-                        lines.NextChar(); // Skip ]
+                        lines.SkipChar(); // Skip ]
                         if (allowEmpty || hasNonWhiteSpace)
                         {
                             // Remove trailing spaces

--- a/src/Markdig/Helpers/StringLineGroup.cs
+++ b/src/Markdig/Helpers/StringLineGroup.cs
@@ -223,7 +223,7 @@ namespace Markdig.Helpers
                 {
                     End += lines.Lines[i].Slice.Length + 1; // Add chars
                 }
-                NextChar();
+                SkipChar();
             }
 
             public int Start { get; private set; }
@@ -287,7 +287,11 @@ namespace Markdig.Helpers
                 return CurrentChar;
             }
 
-            public readonly char PeekChar(int offset = 1)
+            public void SkipChar() => NextChar();
+
+            public readonly char PeekChar() => PeekChar(1);
+
+            public readonly char PeekChar(int offset)
             {
                 if (offset < 0) ThrowHelper.ArgumentOutOfRangeException("Negative offset are not supported for StringLineGroup", nameof(offset));
 

--- a/src/Markdig/Helpers/StringSlice.cs
+++ b/src/Markdig/Helpers/StringSlice.cs
@@ -119,6 +119,17 @@ namespace Markdig.Helpers
             return Text[start];
         }
 
+        /// <summary>
+        /// Goes to the next character, incrementing the <see cref="Start" /> position.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SkipChar()
+        {
+            int start = Start;
+            if (start <= End)
+                Start = start + 1;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal int CountAndSkipChar(char matchChar)
         {

--- a/src/Markdig/Markdown.cs
+++ b/src/Markdig/Markdown.cs
@@ -19,7 +19,9 @@ namespace Markdig
     /// </summary>
     public static partial class Markdown
     {
-        public static readonly string Version = ((AssemblyFileVersionAttribute) typeof(Markdown).Assembly.GetCustomAttributes(typeof(AssemblyFileVersionAttribute), false)[0]).Version;
+        public static readonly string Version = ((AssemblyFileVersionAttribute)typeof(Markdown).Assembly.GetCustomAttributes(typeof(AssemblyFileVersionAttribute), false)[0]).Version;
+
+        private static readonly MarkdownPipeline _defaultPipeline = new MarkdownPipelineBuilder().Build();
 
         /// <summary>
         /// Normalizes the specified markdown to a normalized markdown text.
@@ -47,8 +49,9 @@ namespace Markdig
         /// <returns>A normalized markdown text.</returns>
         public static MarkdownDocument Normalize(string markdown, TextWriter writer, NormalizeOptions options = null, MarkdownPipeline pipeline = null, MarkdownParserContext context = null)
         {
-            pipeline ??= new MarkdownPipelineBuilder().Build();
-            pipeline = CheckForSelfPipeline(pipeline, markdown);
+            pipeline = pipeline is null
+                ? _defaultPipeline
+                : CheckForSelfPipeline(pipeline, markdown);
 
             // We override the renderer with our own writer
             var renderer = new NormalizeRenderer(writer, options);
@@ -71,8 +74,10 @@ namespace Markdig
         public static string ToHtml(string markdown, MarkdownPipeline pipeline = null)
         {
             if (markdown == null) ThrowHelper.ArgumentNullException_markdown();
-            pipeline ??= new MarkdownPipelineBuilder().Build();
-            pipeline = CheckForSelfPipeline(pipeline, markdown);
+
+            pipeline = pipeline is null
+                ? _defaultPipeline
+                : CheckForSelfPipeline(pipeline, markdown);
 
             var renderer = pipeline.GetCacheableHtmlRenderer();
 
@@ -98,8 +103,10 @@ namespace Markdig
         {
             if (markdown == null) ThrowHelper.ArgumentNullException_markdown();
             if (writer == null) ThrowHelper.ArgumentNullException_writer();
-            pipeline ??= new MarkdownPipelineBuilder().Build();
-            pipeline = CheckForSelfPipeline(pipeline, markdown);
+
+            pipeline = pipeline is null
+                ? _defaultPipeline
+                : CheckForSelfPipeline(pipeline, markdown);
 
             // We override the renderer with our own writer
             var renderer = new HtmlRenderer(writer);
@@ -124,9 +131,11 @@ namespace Markdig
         {
             if (markdown == null) ThrowHelper.ArgumentNullException_markdown();
             if (renderer == null) ThrowHelper.ArgumentNullException(nameof(renderer));
-            pipeline ??= new MarkdownPipelineBuilder().Build();
 
-            pipeline = CheckForSelfPipeline(pipeline, markdown);
+            pipeline = pipeline is null
+                ? _defaultPipeline
+                : CheckForSelfPipeline(pipeline, markdown);
+
             var document = Parse(markdown, pipeline, context);
             pipeline.Setup(renderer);
             return renderer.Render(document);
@@ -155,9 +164,11 @@ namespace Markdig
         public static MarkdownDocument Parse(string markdown, MarkdownPipeline pipeline, MarkdownParserContext context = null)
         {
             if (markdown == null) ThrowHelper.ArgumentNullException_markdown();
-            pipeline ??= new MarkdownPipelineBuilder().Build();
 
-            pipeline = CheckForSelfPipeline(pipeline, markdown);
+            pipeline = pipeline is null
+                ? _defaultPipeline
+                : CheckForSelfPipeline(pipeline, markdown);
+
             return MarkdownParser.Parse(markdown, pipeline, context);
         }
 
@@ -184,8 +195,10 @@ namespace Markdig
         {
             if (markdown == null) ThrowHelper.ArgumentNullException_markdown();
             if (writer == null) ThrowHelper.ArgumentNullException_writer();
-            pipeline ??= new MarkdownPipelineBuilder().Build();
-            pipeline = CheckForSelfPipeline(pipeline, markdown);
+
+            pipeline = pipeline is null
+                ? _defaultPipeline
+                : CheckForSelfPipeline(pipeline, markdown);
 
             // We override the renderer with our own writer
             var renderer = new HtmlRenderer(writer)

--- a/src/Markdig/MarkdownPipeline.cs
+++ b/src/Markdig/MarkdownPipeline.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Text;
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Renderers;
@@ -62,40 +63,74 @@ namespace Markdig
         }
 
 
-        private HtmlRendererCache _rendererCache = null;
+        private HtmlRendererCache _rendererCache, _rendererCacheForCustomWriter;
 
-        internal HtmlRenderer GetCacheableHtmlRenderer()
+        internal RentedHtmlRenderer RentHtmlRenderer(TextWriter writer = null)
         {
-            if (_rendererCache is null)
+            HtmlRendererCache cache = writer is null
+                ? _rendererCache ??= new HtmlRendererCache(this, customWriter: false)
+                : _rendererCacheForCustomWriter ??= new HtmlRendererCache(this, customWriter: true);
+
+            var renderer = cache.Get();
+
+            if (writer != null)
             {
-                _rendererCache = new HtmlRendererCache
-                {
-                    OnNewInstanceCreated = Setup
-                };
+                renderer.Writer = writer;
             }
-            return _rendererCache.Get();
-        }
-        internal void ReleaseCacheableHtmlRenderer(HtmlRenderer renderer)
-        {
-            _rendererCache.Release(renderer);
+
+            return new RentedHtmlRenderer(cache, renderer);
         }
 
-        private sealed class HtmlRendererCache : ObjectCache<HtmlRenderer>
+        internal sealed class HtmlRendererCache : ObjectCache<HtmlRenderer>
         {
-            public Action<HtmlRenderer> OnNewInstanceCreated;
+            private const int InitialCapacity = 1024;
+
+            private static readonly StringWriter _dummyWriter = new StringWriter();
+
+            private readonly MarkdownPipeline _pipeline;
+            private readonly bool _customWriter;
+
+            public HtmlRendererCache(MarkdownPipeline pipeline, bool customWriter = false)
+            {
+                _pipeline = pipeline;
+                _customWriter = customWriter;
+            }
 
             protected override HtmlRenderer NewInstance()
             {
-                var writer = new StringWriter();
+                var writer = _customWriter ? _dummyWriter : new StringWriter(new StringBuilder(InitialCapacity));
                 var renderer = new HtmlRenderer(writer);
-                OnNewInstanceCreated(renderer);
+                _pipeline.Setup(renderer);
                 return renderer;
             }
 
             protected override void Reset(HtmlRenderer instance)
             {
                 instance.Reset();
+
+                if (_customWriter)
+                {
+                    instance.Writer = _dummyWriter;
+                }
+                else
+                {
+                    ((StringWriter)instance.Writer).GetStringBuilder().Length = 0;
+                }
             }
+        }
+
+        internal readonly struct RentedHtmlRenderer : IDisposable
+        {
+            private readonly HtmlRendererCache _cache;
+            public HtmlRenderer Instance { get; }
+
+            internal RentedHtmlRenderer(HtmlRendererCache cache, HtmlRenderer renderer)
+            {
+                _cache = cache;
+                Instance = renderer;
+            }
+
+            public void Dispose() => _cache.Release(Instance);
         }
     }
 }

--- a/src/Markdig/Parsers/BlockProcessor.cs
+++ b/src/Markdig/Parsers/BlockProcessor.cs
@@ -212,7 +212,7 @@ namespace Markdig.Parsers
             }
             else
             {
-                Line.NextChar();
+                Line.SkipChar();
                 Column++;
             }
         }

--- a/src/Markdig/Parsers/HtmlBlockParser.cs
+++ b/src/Markdig/Parsers/HtmlBlockParser.cs
@@ -49,7 +49,7 @@ namespace Markdig.Parsers
 
             var line = state.Line;
             var startPosition = line.Start;
-            line.NextChar();
+            line.SkipChar();
             var result = TryParseTagType16(state, line, state.ColumnBeforeIndent, startPosition);
 
             // HTML blocks of type 7 cannot interrupt a paragraph:

--- a/src/Markdig/Parsers/Inlines/EmphasisInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/EmphasisInlineParser.cs
@@ -144,7 +144,7 @@ namespace Markdig.Parsers.Inlines
             char pc = (char)0;
             if (processor.Inline is HtmlEntityInline htmlEntityInline)
             {
-                if (htmlEntityInline.Transcoded.Length > 0)
+                if (!htmlEntityInline.Transcoded.IsEmpty)
                 {
                     pc = htmlEntityInline.Transcoded[htmlEntityInline.Transcoded.End];
                 }

--- a/src/Markdig/Parsers/Inlines/EscapeInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/EscapeInlineParser.cs
@@ -36,7 +36,7 @@ namespace Markdig.Parsers.Inlines
                     IsFirstCharacterEscaped = true,
                 };
                 processor.Inline.Span.End = processor.Inline.Span.Start + 1;
-                slice.NextChar();
+                slice.SkipChar();
                 return true;
             }
 
@@ -52,7 +52,7 @@ namespace Markdig.Parsers.Inlines
                     Column = column
                 };
                 processor.Inline.Span.End = processor.Inline.Span.Start + 1;
-                slice.NextChar();
+                slice.SkipChar();
                 return true;
             }
             return false;

--- a/src/Markdig/Parsers/Inlines/LineBreakInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LineBreakInlineParser.cs
@@ -37,7 +37,7 @@ namespace Markdig.Parsers.Inlines
 
             var startPosition = slice.Start;
             var hasDoubleSpacesBefore = slice.PeekCharExtra(-1).IsSpace() && slice.PeekCharExtra(-2).IsSpace();
-            slice.NextChar(); // Skip \n
+            slice.SkipChar(); // Skip \n
 
             processor.Inline = new LineBreakInline
             {

--- a/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
@@ -60,7 +60,7 @@ namespace Markdig.Parsers.Inlines
                     slice = saved;
 
                     // Else we insert a LinkDelimiter
-                    slice.NextChar();
+                    slice.SkipChar();
                     processor.Inline = new LinkDelimiterInline(this)
                     {
                         Type = DelimiterType.Open,
@@ -74,7 +74,7 @@ namespace Markdig.Parsers.Inlines
                     return true;
 
                 case ']':
-                    slice.NextChar();
+                    slice.SkipChar();
                     if (processor.Inline != null)
                     {
                         if (TryProcessLinkOrImage(processor, ref slice))
@@ -252,8 +252,8 @@ namespace Markdig.Parsers.Inlines
                     label = openParent.Label;
                     labelSpan = openParent.LabelSpan;
                     isLabelSpanLocal = false;
-                    text.NextChar(); // Skip [
-                    text.NextChar(); // Skip ]
+                    text.SkipChar(); // Skip [
+                    text.SkipChar(); // Skip ]
                 }
             }
             else

--- a/src/Markdig/Parsers/MarkdownParser.cs
+++ b/src/Markdig/Parsers/MarkdownParser.cs
@@ -26,8 +26,6 @@ namespace Markdig.Parsers
         private readonly ProcessDocumentDelegate documentProcessed;
         private readonly bool preciseSourceLocation;
 
-        private readonly int roughLineCountEstimate;
-
         private LineReader lineReader;
 
         /// <summary>
@@ -43,7 +41,6 @@ namespace Markdig.Parsers
             if (text == null) ThrowHelper.ArgumentNullException_text();
             if (pipeline == null) ThrowHelper.ArgumentNullException(nameof(pipeline));
 
-            roughLineCountEstimate = text.Length / 40;
             text = FixupZero(text);
             lineReader = new LineReader(text);
             preciseSourceLocation = pipeline.PreciseSourceLocation;
@@ -61,6 +58,12 @@ namespace Markdig.Parsers
             };
 
             documentProcessed = pipeline.DocumentProcessed;
+
+            if (preciseSourceLocation)
+            {
+                int roughLineCountEstimate = text.Length / 40;
+                document.LineStartIndexes = new List<int>(Math.Min(512, roughLineCountEstimate));
+            }
         }
 
         /// <summary>
@@ -87,12 +90,6 @@ namespace Markdig.Parsers
         /// <returns>A document instance</returns>
         private MarkdownDocument Parse()
         {
-            if (preciseSourceLocation)
-            {
-                // Save some List resizing allocations
-                document.LineStartIndexes = new List<int>(Math.Min(512, roughLineCountEstimate));
-            }
-
             ProcessBlocks();
             ProcessInlines();
 

--- a/src/Markdig/Renderers/Normalize/Inlines/LiteralInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/LiteralInlineRenderer.cs
@@ -15,7 +15,7 @@ namespace Markdig.Renderers.Normalize.Inlines
     {
         protected override void Write(NormalizeRenderer renderer, LiteralInline obj)
         {
-            if (obj.IsFirstCharacterEscaped && obj.Content.Length > 0 && obj.Content[obj.Content.Start].IsAsciiPunctuation())
+            if (obj.IsFirstCharacterEscaped && !obj.Content.IsEmpty && obj.Content[obj.Content.Start].IsAsciiPunctuation())
             {
                 renderer.Write('\\');
             }

--- a/src/Markdig/Renderers/TextRendererBase.cs
+++ b/src/Markdig/Renderers/TextRendererBase.cs
@@ -28,9 +28,7 @@ namespace Markdig.Renderers
         protected TextRendererBase(TextWriter writer)
         {
             if (writer == null) ThrowHelper.ArgumentNullException_writer();
-            this.Writer = writer;
-            // By default we output a newline with '\n' only even on Windows platforms
-            Writer.NewLine = "\n";
+            Writer = writer;
         }
 
         /// <summary>
@@ -47,6 +45,8 @@ namespace Markdig.Renderers
                     ThrowHelper.ArgumentNullException(nameof(value));
                 }
 
+                // By default we output a newline with '\n' only even on Windows platforms
+                value.NewLine = "\n";
                 writer = value;
             }
         }
@@ -92,15 +92,6 @@ namespace Markdig.Renderers
 
         internal void Reset()
         {
-            if (Writer is StringWriter stringWriter)
-            {
-                stringWriter.GetStringBuilder().Length = 0;
-            }
-            else
-            {
-                ThrowHelper.InvalidOperationException("Cannot reset this TextWriter instance");
-            }
-
             previousWasLine = true;
             indents.Clear();
         }


### PR DESCRIPTION
Codegen tweaks and allocation improvements.

Removing the overheads in the simple `Markdown.ToHtml(...)` case with the default pipeline.
For an empty string allocations go from 17.14 KB to 928 B and take 1/20th the time because of the default pipeline caching (2af8b1f) - means we're now benefiting from the Renderer caching from https://github.com/lunet-io/markdig/commit/afe4308e918b8afa5d5359d2fab270b4621ef3ab in the basic use cases.

For c776d18 I was quite surprised how bad the compiler is at avoiding these allocations :/