### PR TITLE
Add depth limits to avoid pathological-case parsing times/StackOverflows

### DIFF
--- a/src/Markdig.Tests/MiscTests.cs
+++ b/src/Markdig.Tests/MiscTests.cs
@@ -62,6 +62,29 @@ namespace Markdig.Tests
             }
         }
 
+        [Theory]
+        [TestCase('[', 9 * 1024, true, false)]
+        [TestCase('[', 11 * 1024, true, true)]
+        [TestCase('[', 100, false, false)]
+        [TestCase('[', 150, false, true)]
+        [TestCase('>', 100, true, false)]
+        [TestCase('>', 150, true, true)]
+        public void GuardsAgainstHighlyNestedNodes(char c, int count, bool parseOnly, bool shouldThrow)
+        {
+            var markdown = new string(c, count);
+            TestDelegate test = parseOnly ? () => Markdown.Parse(markdown) : () => Markdown.ToHtml(markdown);
+
+            if (shouldThrow)
+            {
+                Exception e = Assert.Throws<ArgumentException>(test);
+                Assert.True(e.Message.Contains("depth limit"));
+            }
+            else
+            {
+                test();
+            }
+        }
+
         [Test]
         public void IsIssue356Corrected()
         {

--- a/src/Markdig/Markdig.targets
+++ b/src/Markdig/Markdig.targets
@@ -13,7 +13,7 @@
     <PackageIcon>markdig.png</PackageIcon>
     <PackageProjectUrl>https://github.com/lunet-io/markdig</PackageProjectUrl>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <!--Add support for sourcelink-->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/Markdig/Parsers/InlineProcessor.cs
+++ b/src/Markdig/Parsers/InlineProcessor.cs
@@ -307,7 +307,7 @@ namespace Markdig.Parsers
         private ContainerInline FindLastContainer()
         {
             var container = Block.Inline;
-            while (true)
+            for (int depth = 0; ; depth++)
             {
                 if (container.LastChild is ContainerInline nextContainer && !nextContainer.IsClosed)
                 {
@@ -315,10 +315,10 @@ namespace Markdig.Parsers
                 }
                 else
                 {
-                    break;
+                    ThrowHelper.CheckDepthLimit(depth, useLargeLimit: true);
+                    return container;
                 }
             }
-            return container;
         }
     }
 }

--- a/src/Markdig/Parsers/MarkdownParser.cs
+++ b/src/Markdig/Parsers/MarkdownParser.cs
@@ -191,6 +191,7 @@ namespace Markdig.Parsers
                         newItem.Container = (ContainerBlock)block;
                         block.OnProcessInlinesBegin(inlineProcessor);
                         newItem.Index = 0;
+                        ThrowHelper.CheckDepthLimit(blocks.Count);
                         blocks.Push(newItem);
                         goto process_new_block;
                     }

--- a/src/Markdig/Renderers/RendererBase.cs
+++ b/src/Markdig/Renderers/RendererBase.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using Markdig.Helpers;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 
@@ -18,6 +19,7 @@ namespace Markdig.Renderers
         private readonly Dictionary<Type, IMarkdownObjectRenderer> renderersPerType;
         private IMarkdownObjectRenderer previousRenderer;
         private Type previousObjectType;
+        internal int childrenDepth = 0;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RendererBase"/> class.
@@ -57,6 +59,8 @@ namespace Markdig.Renderers
                 return;
             }
 
+            ThrowHelper.CheckDepthLimit(childrenDepth++);
+
             bool saveIsFirstInContainer = IsFirstInContainer;
             bool saveIsLastInContainer = IsLastInContainer;
 
@@ -70,6 +74,8 @@ namespace Markdig.Renderers
 
             IsFirstInContainer = saveIsFirstInContainer;
             IsLastInContainer = saveIsLastInContainer;
+
+            childrenDepth--;
         }
 
         /// <summary>
@@ -82,6 +88,8 @@ namespace Markdig.Renderers
             {
                 return;
             }
+
+            ThrowHelper.CheckDepthLimit(childrenDepth++);
 
             bool saveIsFirstInContainer = IsFirstInContainer;
             bool saveIsLastInContainer = IsLastInContainer;
@@ -101,6 +109,8 @@ namespace Markdig.Renderers
 
             IsFirstInContainer = saveIsFirstInContainer;
             IsLastInContainer = saveIsLastInContainer;
+
+            childrenDepth--;
         }
 
         /// <summary>

--- a/src/Markdig/Renderers/TextRendererBase.cs
+++ b/src/Markdig/Renderers/TextRendererBase.cs
@@ -101,6 +101,7 @@ namespace Markdig.Renderers
                 ThrowHelper.InvalidOperationException("Cannot reset this TextWriter instance");
             }
 
+            childrenDepth = 0;
             previousWasLine = true;
             indents.Clear();
         }

--- a/src/Markdig/Syntax/Block.cs
+++ b/src/Markdig/Syntax/Block.cs
@@ -2,6 +2,7 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
+using Markdig.Helpers;
 using Markdig.Parsers;
 
 namespace Markdig.Syntax
@@ -79,6 +80,7 @@ namespace Markdig.Syntax
         public void UpdateSpanEnd(int spanEnd)
         {
             // Update parent spans
+            int depth = 0;
             var parent = this;
             while (parent != null)
             {
@@ -87,7 +89,9 @@ namespace Markdig.Syntax
                     parent.Span.End = spanEnd;
                 }
                 parent = parent.Parent;
+                depth++;
             }
+            ThrowHelper.CheckDepthLimit(depth, useLargeLimit: true);
         }
     }
 }


### PR DESCRIPTION
Fixes #497 

Due to the recursive approach to rendering, a very deep AST would trigger a StackOverflow during rendering.
This PR adds a general depth limit used in the rendering phase to detect deep nesting (currently 128 which can't affect any non-malicious inputs).
This shouldn't be problematic at all, offering a cheap fail-fast and StackOverflow protection.

Some inputs hit trivial O(n^2) cases due to depth - `new string('[', 100_000)` or `new string('>', 100_000)`.
It also adds a large depth limit used to fail-fast such inputs that would otherwise take ***minutes*** to process.
The current limit of `10 * 1024` is rather arbitrary - on my machine it means that such inputs will fail after ~200 ms.
For comparison, 8192 results in ~125 ms and 16384 in ~500 ms.
**Note: the problem with this limit is that it limits the maximum size of a pipe table due to the way the parser is implemented (#180) - ~10k table cells.**

Should the second part (large limit also affecting tables) be configurable?
We may be able to avoid the table limitation in the future if we revisit the table parsing logic.

CC: @leonyang12

Users can semi-easily avoid the rendering StackOverflow by analyzing the AST after the parsing step (https://gist.github.com/MihaZupan/2e25659bc9af623589df1d1cb1ce712c).

Without a change directly in Markdig, I don't think avoiding the very long `Parse` times is practical.


This PR does **not guarantee** that ALL possible malicious-like inputs will fail-fast.