### PR TITLE
Fix CodeInline to plain text incorrect escape

### DIFF
--- a/src/Markdig.Tests/TestPlainText.cs
+++ b/src/Markdig.Tests/TestPlainText.cs
@@ -21,6 +21,7 @@ namespace Markdig.Tests
         [TestCase(/* markdownText: */ "- foo\n- bar\n- baz", /* expected: */ "foo\nbar\nbaz\n")]
         [TestCase(/* markdownText: */ "- foo<baz", /* expected: */ "foo<baz\n")]
         [TestCase(/* markdownText: */ "- foo&lt;baz", /* expected: */ "foo<baz\n")]
+        [TestCase(/* markdownText: */ "## foo `bar::baz >`", /* expected: */ "foo bar::baz >\n")]
         public void TestPlainEnsureNewLine(string markdownText, string expected)
         {            
             var actual = Markdown.ToPlainText(markdownText);

--- a/src/Markdig/Renderers/Html/Inlines/CodeInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/CodeInlineRenderer.cs
@@ -18,7 +18,14 @@ namespace Markdig.Renderers.Html.Inlines
             {
                 renderer.Write("<code").WriteAttributes(obj).Write(">");
             }
-            renderer.WriteEscape(obj.Content);
+            if (renderer.EnableHtmlEscape)
+            {
+                renderer.WriteEscape(obj.Content);
+            }
+            else
+            {
+                renderer.Write(obj.Content);
+            }
             if (renderer.EnableHtmlForInline)
             {
                 renderer.Write("</code>");


### PR DESCRIPTION
Fixes #495 

This PR fixes `CodeInlineRenderer` the same way as [LiteralInlineRenderer](https://github.com/xoofx/markdig/blob/master/src/Markdig/Renderers/Html/Inlines/LiteralInlineRenderer.cs) by checking `EnableHtmlEscape` and call different methods accordingly.