### PR TITLE
Expose `TextRendererBase.Reset` method to inheritors

### DIFF
--- a/src/Markdig/Renderers/TextRendererBase.cs
+++ b/src/Markdig/Renderers/TextRendererBase.cs
@@ -90,7 +90,7 @@ namespace Markdig.Renderers
             indents = new List<string>();
         }
 
-        internal void Reset()
+        protected internal void Reset()
         {
             if (Writer is StringWriter stringWriter)
             {


### PR DESCRIPTION
Fixes #508 by exposing the [`TextRendererBase.Reset`](https://github.com/xoofx/markdig/blob/3030b72f781f902cb947a173853de95de8924c6c/src/Markdig/Renderers/TextRendererBase.cs#L93-L107) method to the class inheritors.
That change makes it possible to implement custom caches of `HtmlRenderer` instances.