### PR TITLE
ADD: Markdown.ToHtml from MarkdownDocument

### DIFF
--- a/src/Markdig/Markdown.cs
+++ b/src/Markdig/Markdown.cs
@@ -93,7 +93,7 @@ namespace Markdig
         /// <param name="pipeline">The pipeline used for the conversion.</param>
         /// <returns>The result of the conversion</returns>
         /// <exception cref="ArgumentNullException">if markdown document variable is null</exception>
-        public static string ToHtml(MarkdownDocument document, MarkdownPipeline pipeline = null)
+        public static string ToHtml(this MarkdownDocument document, MarkdownPipeline pipeline = null)
         {
             if (document == null) ThrowHelper.ArgumentNullException(nameof(document));
             pipeline ??= new MarkdownPipelineBuilder().Build();

--- a/src/Markdig/Markdown.cs
+++ b/src/Markdig/Markdown.cs
@@ -87,6 +87,28 @@ namespace Markdig
         }
 
         /// <summary>
+        /// Converts a Markdown document to HTML.
+        /// </summary>
+        /// <param name="document">A Markdown document.</param>
+        /// <param name="pipeline">The pipeline used for the conversion.</param>
+        /// <returns>The result of the conversion</returns>
+        /// <exception cref="ArgumentNullException">if markdown document variable is null</exception>
+        public static string ToHtml(MarkdownDocument document, MarkdownPipeline pipeline = null)
+        {
+            if (document == null) ThrowHelper.ArgumentNullException(nameof(document));
+            pipeline ??= new MarkdownPipelineBuilder().Build();
+
+            var renderer = pipeline.GetCacheableHtmlRenderer();
+
+            renderer.Render(document);
+            renderer.Writer.Flush();
+
+            string html = renderer.Writer.ToString();
+            pipeline.ReleaseCacheableHtmlRenderer(renderer);
+            return html;
+        }
+
+        /// <summary>
         /// Converts a Markdown string to HTML and output to the specified writer.
         /// </summary>
         /// <param name="markdown">A Markdown text.</param>


### PR DESCRIPTION
Hello. In my case, I had to add additional classes in html elements. And the best way, in my opinion, was to add attributes on parsed document, and then render this one. And I added this missed method.
Code in my local project:
```
if (inline is LinkInline link)
{
   link.GetAttributes()
      .AddClass("mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1");
}
```