### PR TITLE
Random perf improvements

### DIFF
--- a/src/Markdig.Tests/TestMarkdigCoreApi.cs
+++ b/src/Markdig.Tests/TestMarkdigCoreApi.cs
@@ -11,11 +11,14 @@ namespace Markdig.Tests
         [Test]
         public void TestToHtml()
         {
-            string html = Markdown.ToHtml("This is a text with some *emphasis*");
-            Assert.AreEqual("<p>This is a text with some <em>emphasis</em></p>\n", html);
+            for (int i = 0; i < 5; i++)
+            {
+                string html = Markdown.ToHtml("This is a text with some *emphasis*");
+                Assert.AreEqual("<p>This is a text with some <em>emphasis</em></p>\n", html);
 
-            html = Markdown.ToHtml("This is a text with a https://link.tld/");
-            Assert.AreNotEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
+                html = Markdown.ToHtml("This is a text with a https://link.tld/");
+                Assert.AreNotEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
+            }
         }
 
         [Test]
@@ -24,49 +27,66 @@ namespace Markdig.Tests
             var pipeline = new MarkdownPipelineBuilder()
                 .Build();
 
-            string html = Markdown.ToHtml("This is a text with some *emphasis*", pipeline);
-            Assert.AreEqual("<p>This is a text with some <em>emphasis</em></p>\n", html);
+            for (int i = 0; i < 5; i++)
+            {
+                string html = Markdown.ToHtml("This is a text with some *emphasis*", pipeline);
+                Assert.AreEqual("<p>This is a text with some <em>emphasis</em></p>\n", html);
 
-            html = Markdown.ToHtml("This is a text with a https://link.tld/", pipeline);
-            Assert.AreNotEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
+                html = Markdown.ToHtml("This is a text with a https://link.tld/", pipeline);
+                Assert.AreNotEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
+            }
 
             pipeline = new MarkdownPipelineBuilder()
                 .UseAdvancedExtensions()
                 .Build();
 
-            html = Markdown.ToHtml("This is a text with a https://link.tld/", pipeline);
-            Assert.AreEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
+            for (int i = 0; i < 5; i++)
+            {
+                string html = Markdown.ToHtml("This is a text with a https://link.tld/", pipeline);
+                Assert.AreEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
+            }
         }
 
         [Test]
         public void TestToHtmlWithWriter()
         {
-            StringWriter writer = new StringWriter();
+            var writer = new StringWriter();
 
-            _ = Markdown.ToHtml("This is a text with some *emphasis*", writer);
-            string html = writer.ToString();
-            Assert.AreEqual("<p>This is a text with some <em>emphasis</em></p>\n", html);
+            for (int i = 0; i < 5; i++)
+            {
+                _ = Markdown.ToHtml("This is a text with some *emphasis*", writer);
+                string html = writer.ToString();
+                Assert.AreEqual("<p>This is a text with some <em>emphasis</em></p>\n", html);
+                writer.GetStringBuilder().Length = 0;
+            }
 
             writer = new StringWriter();
             var pipeline = new MarkdownPipelineBuilder()
                 .UseAdvancedExtensions()
                 .Build();
 
-            _ = Markdown.ToHtml("This is a text with a https://link.tld/", writer, pipeline);
-            html = writer.ToString();
-            Assert.AreEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
-
+            for (int i = 0; i < 5; i++)
+            {
+                _ = Markdown.ToHtml("This is a text with a https://link.tld/", writer, pipeline);
+                string html = writer.ToString();
+                Assert.AreEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
+                writer.GetStringBuilder().Length = 0;
+            }
         }
 
         [Test]
         public void TestConvert()
         {
-            StringWriter writer = new StringWriter();
-            HtmlRenderer renderer = new HtmlRenderer(writer);
+            var writer = new StringWriter();
+            var renderer = new HtmlRenderer(writer);
 
-            _ = Markdown.Convert("This is a text with some *emphasis*", renderer);
-            string html = writer.ToString();
-            Assert.AreEqual("<p>This is a text with some <em>emphasis</em></p>\n", html);
+            for (int i = 0; i < 5; i++)
+            {
+                _ = Markdown.Convert("This is a text with some *emphasis*", renderer);
+                string html = writer.ToString();
+                Assert.AreEqual("<p>This is a text with some <em>emphasis</em></p>\n", html);
+                writer.GetStringBuilder().Length = 0;
+            }
 
             writer = new StringWriter();
             renderer = new HtmlRenderer(writer);
@@ -74,9 +94,13 @@ namespace Markdig.Tests
                 .UseAdvancedExtensions()
                 .Build();
 
-            _ = Markdown.Convert("This is a text with a https://link.tld/", renderer, pipeline);
-            html = writer.ToString();
-            Assert.AreEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
+            for (int i = 0; i < 5; i++)
+            {
+                _ = Markdown.Convert("This is a text with a https://link.tld/", renderer, pipeline);
+                string html = writer.ToString();
+                Assert.AreEqual("<p>This is a text with a <a href=\"https://link.tld/\">https://link.tld/</a></p>\n", html);
+                writer.GetStringBuilder().Length = 0;
+            }
         }
 
         [Test]
@@ -88,62 +112,77 @@ namespace Markdig.Tests
                 .UsePreciseSourceLocation()
                 .Build();
 
-            MarkdownDocument document = Markdown.Parse(markdown, pipeline);
+            for (int i = 0; i < 5; i++)
+            {
+                MarkdownDocument document = Markdown.Parse(markdown, pipeline);
 
-            Assert.AreEqual(1, document.LineCount);
-            Assert.AreEqual(markdown.Length, document.Span.Length);
-            Assert.AreEqual(1, document.LineStartIndexes.Count);
-            Assert.AreEqual(0, document.LineStartIndexes[0]);
+                Assert.AreEqual(1, document.LineCount);
+                Assert.AreEqual(markdown.Length, document.Span.Length);
+                Assert.AreEqual(1, document.LineStartIndexes.Count);
+                Assert.AreEqual(0, document.LineStartIndexes[0]);
 
-            Assert.AreEqual(1, document.Count);
-            ParagraphBlock paragraph = document[0] as ParagraphBlock;
-            Assert.NotNull(paragraph);
-            Assert.AreEqual(markdown.Length, paragraph.Span.Length);
-            LiteralInline literal = paragraph.Inline.FirstChild as LiteralInline;
-            Assert.NotNull(literal);
-            Assert.AreEqual("This is a text with some ", literal.ToString());
-            EmphasisInline emphasis = literal.NextSibling as EmphasisInline;
-            Assert.NotNull(emphasis);
-            Assert.AreEqual("*emphasis*".Length, emphasis.Span.Length);
-            LiteralInline emphasisLiteral = emphasis.FirstChild as LiteralInline;
-            Assert.NotNull(emphasisLiteral);
-            Assert.AreEqual("emphasis", emphasisLiteral.ToString());
-            Assert.Null(emphasisLiteral.NextSibling);
-            Assert.Null(emphasis.NextSibling);
+                Assert.AreEqual(1, document.Count);
+                ParagraphBlock paragraph = document[0] as ParagraphBlock;
+                Assert.NotNull(paragraph);
+                Assert.AreEqual(markdown.Length, paragraph.Span.Length);
+                LiteralInline literal = paragraph.Inline.FirstChild as LiteralInline;
+                Assert.NotNull(literal);
+                Assert.AreEqual("This is a text with some ", literal.ToString());
+                EmphasisInline emphasis = literal.NextSibling as EmphasisInline;
+                Assert.NotNull(emphasis);
+                Assert.AreEqual("*emphasis*".Length, emphasis.Span.Length);
+                LiteralInline emphasisLiteral = emphasis.FirstChild as LiteralInline;
+                Assert.NotNull(emphasisLiteral);
+                Assert.AreEqual("emphasis", emphasisLiteral.ToString());
+                Assert.Null(emphasisLiteral.NextSibling);
+                Assert.Null(emphasis.NextSibling);
+            }
         }
 
         [Test]
         public void TestNormalize()
         {
-            string normalized = Markdown.Normalize("Heading\n=======");
-            Assert.AreEqual("# Heading", normalized);
+            for (int i = 0; i < 5; i++)
+            {
+                string normalized = Markdown.Normalize("Heading\n=======");
+                Assert.AreEqual("# Heading", normalized);
+            }
         }
 
         [Test]
         public void TestNormalizeWithWriter()
         {
-            StringWriter writer = new StringWriter();
+            for (int i = 0; i < 5; i++)
+            {
+                var writer = new StringWriter();
 
-            _ = Markdown.Normalize("Heading\n=======", writer);
-            string normalized = writer.ToString();
-            Assert.AreEqual("# Heading", normalized);
+                _ = Markdown.Normalize("Heading\n=======", writer);
+                string normalized = writer.ToString();
+                Assert.AreEqual("# Heading", normalized);
+            }
         }
 
         [Test]
         public void TestToPlainText()
         {
-            string plainText = Markdown.ToPlainText("*Hello*, [world](http://example.com)!");
-            Assert.AreEqual("Hello, world!\n", plainText);
+            for (int i = 0; i < 5; i++)
+            {
+                string plainText = Markdown.ToPlainText("*Hello*, [world](http://example.com)!");
+                Assert.AreEqual("Hello, world!\n", plainText);
+            }
         }
 
         [Test]
         public void TestToPlainTextWithWriter()
         {
-            StringWriter writer = new StringWriter();
+            for (int i = 0; i < 5; i++)
+            {
+                var writer = new StringWriter();
 
-            _ = Markdown.ToPlainText("*Hello*, [world](http://example.com)!", writer);
-            string plainText = writer.ToString();
-            Assert.AreEqual("Hello, world!\n", plainText);
+                _ = Markdown.ToPlainText("*Hello*, [world](http://example.com)!", writer);
+                string plainText = writer.ToString();
+                Assert.AreEqual("Hello, world!\n", plainText);
+            }
         }
     }
 }

--- a/src/Markdig/Parsers/MarkdownParser.cs
+++ b/src/Markdig/Parsers/MarkdownParser.cs
@@ -160,28 +160,19 @@ namespace Markdig.Parsers
             return text.Replace('\0', CharHelper.ReplacementChar);
         }
 
-        private sealed class ContainerItemCache : DefaultObjectCache<ContainerItem>
-        {
-            protected override void Reset(ContainerItem instance)
-            {
-                instance.Container = null;
-                instance.Index = 0;
-            }
-        }
-
         private void ProcessInlines()
         {
             // "stackless" processor
-            var cache = new ContainerItemCache();
-            var blocks = new Stack<ContainerItem>();
+            int blockCount = 1;
+            var blocks = new ContainerItem[4];
 
-            // TODO: Use an ObjectCache for ContainerItem
-            blocks.Push(new ContainerItem(document));
+            blocks[0] = new ContainerItem(document);
             document.OnProcessInlinesBegin(inlineProcessor);
-            while (blocks.Count > 0)
+
+            while (blockCount != 0)
             {
                 process_new_block:
-                var item = blocks.Peek();
+                ref ContainerItem item = ref blocks[blockCount - 1];
                 var container = item.Container;
 
                 for (; item.Index < container.Count; item.Index++)
@@ -217,35 +208,31 @@ namespace Markdig.Parsers
                             // Else we have processed it
                             item.Index++;
                         }
-                        var newItem = cache.Get();
-                        newItem.Container = (ContainerBlock)block;
-                        block.OnProcessInlinesBegin(inlineProcessor);
-                        newItem.Index = 0;
-                        ThrowHelper.CheckDepthLimit(blocks.Count);
-                        blocks.Push(newItem);
+
+                        if (blockCount == blocks.Length)
+                        {
+                            Array.Resize(ref blocks, blockCount * 2);
+                            ThrowHelper.CheckDepthLimit(blocks.Length);
+                        }
+                        blocks[blockCount++] = new ContainerItem(newContainer);
+                        newContainer.OnProcessInlinesBegin(inlineProcessor);
                         goto process_new_block;
                     }
                 }
-                item = blocks.Pop();
-                container = item.Container;
                 container.OnProcessInlinesEnd(inlineProcessor);
-
-                cache.Release(item);
+                blocks[--blockCount] = default;
             }
         }
 
-        private class ContainerItem
+        private struct ContainerItem
         {
-            public ContainerItem()
-            {
-            }
-
             public ContainerItem(ContainerBlock container)
             {
                 Container = container;
+                Index = 0;
             }
 
-            public ContainerBlock Container;
+            public readonly ContainerBlock Container;
 
             public int Index;
         }

--- a/src/Markdig/Renderers/TextRendererBase.cs
+++ b/src/Markdig/Renderers/TextRendererBase.cs
@@ -28,9 +28,7 @@ namespace Markdig.Renderers
         protected TextRendererBase(TextWriter writer)
         {
             if (writer == null) ThrowHelper.ArgumentNullException_writer();
-            this.Writer = writer;
-            // By default we output a newline with '\n' only even on Windows platforms
-            Writer.NewLine = "\n";
+            Writer = writer;
         }
 
         /// <summary>
@@ -47,6 +45,8 @@ namespace Markdig.Renderers
                     ThrowHelper.ArgumentNullException(nameof(value));
                 }
 
+                // By default we output a newline with '\n' only even on Windows platforms
+                value.NewLine = "\n";
                 writer = value;
             }
         }
@@ -128,6 +128,11 @@ namespace Markdig.Renderers
                 ThrowHelper.InvalidOperationException("Cannot reset this TextWriter instance");
             }
 
+            ResetInternal();
+        }
+
+        internal void ResetInternal()
+        {
             childrenDepth = 0;
             previousWasLine = true;
             indents.Clear();


### PR DESCRIPTION
Brings over some of the changes from #499:
- Caching the default pipeline
- Caching for custom writers
- Reduced MarkdownObject size
- Removed most heap allocations from ProcessInlines loop