### PR TITLE
Complete nullable annotations

### DIFF
--- a/src/Markdig/Extensions/Abbreviations/Abbreviation.cs
+++ b/src/Markdig/Extensions/Abbreviations/Abbreviation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
@@ -27,7 +27,7 @@ namespace Markdig.Extensions.Abbreviations
         /// <summary>
         /// Gets or sets the label.
         /// </summary>
-        public string Label { get; set; }
+        public string? Label { get; set; }
 
         /// <summary>
         /// The text associated to this label.

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationHelper.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationHelper.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Markdig.Helpers;
 using Markdig.Syntax;

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationInline.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationInline.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
@@ -14,13 +14,6 @@ namespace Markdig.Extensions.Abbreviations
     [DebuggerDisplay("{Abbreviation}")]
     public class AbbreviationInline : LeafInline
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AbbreviationInline"/> class.
-        /// </summary>
-        public AbbreviationInline()
-        {
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="AbbreviationInline"/> class.
         /// </summary>

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Markdig.Helpers;

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
@@ -81,7 +81,7 @@ namespace Markdig.Extensions.Abbreviations
 
             var abbreviations = inlineProcessor.Document.GetAbbreviations();
             // Should not happen, but another extension could decide to remove them, so...
-            if (abbreviations == null)
+            if (abbreviations is null)
             {
                 return;
             }
@@ -129,7 +129,7 @@ namespace Markdig.Extensions.Abbreviations
                         var indexAfterMatch = i + match.Length;
 
                         // If we don't have a container, create a new one
-                        if (container == null)
+                        if (container is null)
                         {
                             container = literal.Parent ??
                                 new ContainerInline
@@ -152,7 +152,7 @@ namespace Markdig.Extensions.Abbreviations
                         abbrInline.Span.End = abbrInline.Span.Start + match.Length - 1;
 
                         // Append the previous literal
-                        if (i > content.Start && literal.Parent == null)
+                        if (i > content.Start && literal.Parent is null)
                         {
                             container.AppendChild(literal);
                         }

--- a/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierExtension.cs
+++ b/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierExtension.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using System.IO;
 using Markdig.Helpers;

--- a/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierExtension.cs
+++ b/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierExtension.cs
@@ -76,9 +76,8 @@ namespace Markdig.Extensions.AutoIdentifiers
 
                 var text = headingLine.ToString();
 
-                var linkRef = new HeadingLinkReferenceDefinition()
+                var linkRef = new HeadingLinkReferenceDefinition(headingBlock)
                 {
-                    Heading = headingBlock,
                     CreateLinkInline = CreateLinkInlineForHeading
                 };
 

--- a/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierExtension.cs
+++ b/src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierExtension.cs
@@ -83,7 +83,7 @@ namespace Markdig.Extensions.AutoIdentifiers
 
                 var doc = processor.Document;
                 var dictionary = doc.GetData(this) as Dictionary<string, HeadingLinkReferenceDefinition>;
-                if (dictionary == null)
+                if (dictionary is null)
                 {
                     dictionary = new Dictionary<string, HeadingLinkReferenceDefinition>();
                     doc.SetData(this, dictionary);

--- a/src/Markdig/Extensions/AutoIdentifiers/HeadingLinkReferenceDefinition.cs
+++ b/src/Markdig/Extensions/AutoIdentifiers/HeadingLinkReferenceDefinition.cs
@@ -12,6 +12,11 @@ namespace Markdig.Extensions.AutoIdentifiers
     /// <seealso cref="LinkReferenceDefinition" />
     public class HeadingLinkReferenceDefinition : LinkReferenceDefinition
     {
+        public HeadingLinkReferenceDefinition(HeadingBlock headling)
+        {
+            Heading = headling;
+        }
+
         /// <summary>
         /// Gets or sets the heading related to this link reference definition.
         /// </summary>

--- a/src/Markdig/Extensions/AutoLinks/AutoLinkExtension.cs
+++ b/src/Markdig/Extensions/AutoLinks/AutoLinkExtension.cs
@@ -17,7 +17,7 @@ namespace Markdig.Extensions.AutoLinks
     {
         public readonly AutoLinkOptions Options;
 
-        public AutoLinkExtension(AutoLinkOptions options)
+        public AutoLinkExtension(AutoLinkOptions? options)
         {
             Options = options ?? new AutoLinkOptions();
         }

--- a/src/Markdig/Extensions/AutoLinks/AutoLinkParser.cs
+++ b/src/Markdig/Extensions/AutoLinks/AutoLinkParser.cs
@@ -106,7 +106,7 @@ namespace Markdig.Extensions.AutoLinks
                 }
 
                 // Parse URL
-                if (!LinkHelper.TryParseUrl(ref slice, out string link, out _, true))
+                if (!LinkHelper.TryParseUrl(ref slice, out string? link, out _, true))
                 {
                     return false;
                 }

--- a/src/Markdig/Extensions/Citations/CitationExtension.cs
+++ b/src/Markdig/Extensions/Citations/CitationExtension.cs
@@ -2,11 +2,11 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
+using System.Diagnostics;
 using Markdig.Parsers.Inlines;
 using Markdig.Renderers;
 using Markdig.Renderers.Html.Inlines;
 using Markdig.Syntax.Inlines;
-using System.Diagnostics;
 
 namespace Markdig.Extensions.Citations
 {
@@ -40,7 +40,7 @@ namespace Markdig.Extensions.Citations
             }
         }
 
-        private static string GetTag(EmphasisInline emphasisInline)
+        private static string? GetTag(EmphasisInline emphasisInline)
         {
             Debug.Assert(emphasisInline.DelimiterCount <= 2);
             return emphasisInline.DelimiterCount == 2 && emphasisInline.DelimiterChar == '"' ? "cite" : null;

--- a/src/Markdig/Extensions/CustomContainers/CustomContainer.cs
+++ b/src/Markdig/Extensions/CustomContainers/CustomContainer.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Syntax;

--- a/src/Markdig/Extensions/DefinitionLists/DefinitionListParser.cs
+++ b/src/Markdig/Extensions/DefinitionLists/DefinitionListParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using Markdig.Parsers;
 using Markdig.Syntax;

--- a/src/Markdig/Extensions/DefinitionLists/DefinitionListParser.cs
+++ b/src/Markdig/Extensions/DefinitionLists/DefinitionListParser.cs
@@ -63,7 +63,7 @@ namespace Markdig.Extensions.DefinitionLists
                 paragraphBlock.Parent.Remove(paragraphBlock);
             }
 
-            if (currentDefinitionList == null)
+            if (currentDefinitionList is null)
             {
                 currentDefinitionList = new DefinitionList(this)
                 {
@@ -173,7 +173,7 @@ namespace Markdig.Extensions.DefinitionLists
             var isBreakable = definitionItem.LastChild?.IsBreakable ?? true;
             if (processor.IsBlankLine)
             {
-                if (lastBlankLine == null && isBreakable)
+                if (lastBlankLine is null && isBreakable)
                 {
                     definitionItem.Add(new BlankLineBlock());
                 }

--- a/src/Markdig/Extensions/DefinitionLists/HtmlDefinitionListRenderer.cs
+++ b/src/Markdig/Extensions/DefinitionLists/HtmlDefinitionListRenderer.cs
@@ -55,7 +55,7 @@ namespace Markdig.Extensions.DefinitionLists
                         }
 
                         var nextTerm = i + 1 < definitionItem.Count ? definitionItem[i + 1] : null;
-                        bool isSimpleParagraph = (nextTerm == null || nextTerm is DefinitionItem) && countdd == 0 &&
+                        bool isSimpleParagraph = (nextTerm is null || nextTerm is DefinitionItem) && countdd == 0 &&
                                                  definitionTermOrContent is ParagraphBlock;
 
                         var saveImplicitParagraph = renderer.ImplicitParagraph;

--- a/src/Markdig/Extensions/Diagrams/DiagramExtension.cs
+++ b/src/Markdig/Extensions/Diagrams/DiagramExtension.cs
@@ -21,7 +21,7 @@ namespace Markdig.Extensions.Diagrams
         {
             if (renderer is HtmlRenderer htmlRenderer)
             {
-                var codeRenderer = htmlRenderer.ObjectRenderers.FindExact<CodeBlockRenderer>();
+                var codeRenderer = htmlRenderer.ObjectRenderers.FindExact<CodeBlockRenderer>()!;
                 // TODO: Add other well known diagram languages
                 codeRenderer.BlocksAsDiv.Add("mermaid");
                 codeRenderer.BlocksAsDiv.Add("nomnoml");

--- a/src/Markdig/Extensions/Emoji/EmojiInline.cs
+++ b/src/Markdig/Extensions/Emoji/EmojiInline.cs
@@ -34,6 +34,6 @@ namespace Markdig.Extensions.Emoji
         /// <summary>
         /// Gets or sets the original match string (either an emoji shortcode or a text smiley)
         /// </summary>
-        public string Match { get; set; }
+        public string? Match { get; set; }
     }
 }

--- a/src/Markdig/Extensions/Emoji/EmojiMapping.cs
+++ b/src/Markdig/Extensions/Emoji/EmojiMapping.cs
@@ -1747,10 +1747,10 @@ namespace Markdig.Extensions.Emoji
         /// </summary>
         public EmojiMapping(IDictionary<string, string> shortcodeToUnicode, IDictionary<string, string> smileyToShortcode)
         {
-            if (shortcodeToUnicode == null)
+            if (shortcodeToUnicode is null)
                 ThrowHelper.ArgumentNullException(nameof(shortcodeToUnicode));
 
-            if (smileyToShortcode == null)
+            if (smileyToShortcode is null)
                 ThrowHelper.ArgumentNullException(nameof(smileyToShortcode));
 
             // Build emojis and smileys CompactPrefixTree

--- a/src/Markdig/Extensions/Emoji/EmojiMapping.cs
+++ b/src/Markdig/Extensions/Emoji/EmojiMapping.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Markdig.Helpers;
 

--- a/src/Markdig/Extensions/EmphasisExtras/EmphasisExtraExtension.cs
+++ b/src/Markdig/Extensions/EmphasisExtras/EmphasisExtraExtension.cs
@@ -102,7 +102,7 @@ namespace Markdig.Extensions.EmphasisExtras
             }
         }
 
-        private string GetTag(EmphasisInline emphasisInline)
+        private string? GetTag(EmphasisInline emphasisInline)
         {
             var c = emphasisInline.DelimiterChar;
             switch (c)

--- a/src/Markdig/Extensions/Footnotes/Footnote.cs
+++ b/src/Markdig/Extensions/Footnotes/Footnote.cs
@@ -23,7 +23,7 @@ namespace Markdig.Extensions.Footnotes
         /// <summary>
         /// Gets or sets the label used by this footnote.
         /// </summary>
-        public string Label { get; set; }
+        public string? Label { get; set; }
 
         /// <summary>
         /// Gets or sets the order of this footnote (determined by the order of the <see cref="FootnoteLink"/> in the document)

--- a/src/Markdig/Extensions/Footnotes/FootnoteLink.cs
+++ b/src/Markdig/Extensions/Footnotes/FootnoteLink.cs
@@ -12,6 +12,11 @@ namespace Markdig.Extensions.Footnotes
     /// <seealso cref="Inline" />
     public class FootnoteLink : Inline
     {
+        public FootnoteLink(Footnote footnote)
+        {
+            Footnote = footnote;
+        }
+
         /// <summary>
         /// Gets or sets a value indicating whether this instance is back link (from a footnote to the link)
         /// </summary>

--- a/src/Markdig/Extensions/Footnotes/FootnoteLinkReferenceDefinition.cs
+++ b/src/Markdig/Extensions/Footnotes/FootnoteLinkReferenceDefinition.cs
@@ -12,6 +12,11 @@ namespace Markdig.Extensions.Footnotes
     /// <seealso cref="LinkReferenceDefinition" />
     public class FootnoteLinkReferenceDefinition : LinkReferenceDefinition
     {
+        public FootnoteLinkReferenceDefinition(Footnote footnote)
+        {
+            Footnote = footnote;
+        }
+
         /// <summary>
         /// Gets or sets the footnote related to this link reference definition.
         /// </summary>

--- a/src/Markdig/Extensions/Footnotes/FootnoteParser.cs
+++ b/src/Markdig/Extensions/Footnotes/FootnoteParser.cs
@@ -72,9 +72,8 @@ namespace Markdig.Extensions.Footnotes
             }
             footnotes.Add(footnote);
 
-            var linkRef = new FootnoteLinkReferenceDefinition()
+            var linkRef = new FootnoteLinkReferenceDefinition(footnote)
             {
-                Footnote = footnote,
                 CreateLinkInline = CreateLinkToFootnote,
                 Line = processor.LineIndex,
                 Span = new SourceSpan(start, processor.Start - 2), // account for ]:
@@ -182,11 +181,10 @@ namespace Markdig.Extensions.Footnotes
                 {
                     linkIndex++;
                     link.Index = linkIndex;
-                    var backLink = new FootnoteLink()
+                    var backLink = new FootnoteLink(footnote)
                     {
                         Index = linkIndex,
-                        IsBackLink = true,
-                        Footnote = footnote
+                        IsBackLink = true
                     };
                     paragraphBlock.Inline.AppendChild(backLink);
                 }
@@ -203,7 +201,7 @@ namespace Markdig.Extensions.Footnotes
                 footnote.Order = footnotes.CurrentOrder;
             }
 
-            var link = new FootnoteLink() {Footnote = footnote};
+            var link = new FootnoteLink(footnote);
             footnote.Links.Add(link);
 
             return link;

--- a/src/Markdig/Extensions/Footnotes/FootnoteParser.cs
+++ b/src/Markdig/Extensions/Footnotes/FootnoteParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Syntax;
@@ -63,7 +61,7 @@ namespace Markdig.Extensions.Footnotes
 
             // Maintain a list of all footnotes at document level
             var footnotes = processor.Document.GetData(DocumentKey) as FootnoteGroup;
-            if (footnotes is null)
+            if (footnotes == null)
             {
                 footnotes = new FootnoteGroup(this);
                 processor.Document.Add(footnotes);
@@ -89,7 +87,7 @@ namespace Markdig.Extensions.Footnotes
         {
             var footnote = (Footnote) block;
 
-            if (processor.CurrentBlock is null || processor.CurrentBlock.IsBreakable)
+            if (processor.CurrentBlock == null || processor.CurrentBlock.IsBreakable)
             {
                 if (processor.IsBlankLine)
                 {
@@ -172,7 +170,7 @@ namespace Markdig.Extensions.Footnotes
                     paragraphBlock = new ParagraphBlock();
                     footnote.Add(paragraphBlock);
                 }
-                if (paragraphBlock.Inline is null)
+                if (paragraphBlock.Inline == null)
                 {
                     paragraphBlock.Inline = new ContainerInline();
                 }

--- a/src/Markdig/Extensions/Footnotes/FootnoteParser.cs
+++ b/src/Markdig/Extensions/Footnotes/FootnoteParser.cs
@@ -63,7 +63,7 @@ namespace Markdig.Extensions.Footnotes
 
             // Maintain a list of all footnotes at document level
             var footnotes = processor.Document.GetData(DocumentKey) as FootnoteGroup;
-            if (footnotes == null)
+            if (footnotes is null)
             {
                 footnotes = new FootnoteGroup(this);
                 processor.Document.Add(footnotes);
@@ -89,7 +89,7 @@ namespace Markdig.Extensions.Footnotes
         {
             var footnote = (Footnote) block;
 
-            if (processor.CurrentBlock == null || processor.CurrentBlock.IsBreakable)
+            if (processor.CurrentBlock is null || processor.CurrentBlock.IsBreakable)
             {
                 if (processor.IsBlankLine)
                 {
@@ -172,7 +172,7 @@ namespace Markdig.Extensions.Footnotes
                     paragraphBlock = new ParagraphBlock();
                     footnote.Add(paragraphBlock);
                 }
-                if (paragraphBlock.Inline == null)
+                if (paragraphBlock.Inline is null)
                 {
                     paragraphBlock.Inline = new ContainerInline();
                 }

--- a/src/Markdig/Extensions/GenericAttributes/GenericAttributesExtension.cs
+++ b/src/Markdig/Extensions/GenericAttributes/GenericAttributesExtension.cs
@@ -51,7 +51,7 @@ namespace Markdig.Extensions.GenericAttributes
                     var copy = line;
                     copy.Start = indexOfAttributes;
                     var startOfAttributes = copy.Start;
-                    if (GenericAttributesParser.TryParse(ref copy, out HtmlAttributes attributes))
+                    if (GenericAttributesParser.TryParse(ref copy, out HtmlAttributes? attributes))
                     {
                         var htmlAttributes = block.GetAttributes();
                         attributes.CopyTo(htmlAttributes);

--- a/src/Markdig/Extensions/GenericAttributes/GenericAttributesParser.cs
+++ b/src/Markdig/Extensions/GenericAttributes/GenericAttributesParser.cs
@@ -137,7 +137,7 @@ namespace Markdig.Extensions.GenericAttributes
                     var text = slice.Text.Substring(start, end - start + 1);
                     if (isClass)
                     {
-                        if (classes == null)
+                        if (classes is null)
                         {
                             classes = new List<string>();
                         }

--- a/src/Markdig/Extensions/GenericAttributes/GenericAttributesParser.cs
+++ b/src/Markdig/Extensions/GenericAttributes/GenericAttributesParser.cs
@@ -3,6 +3,8 @@
 // See the license.txt file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Renderers.Html;
@@ -28,7 +30,7 @@ namespace Markdig.Extensions.GenericAttributes
         public override bool Match(InlineProcessor processor, ref StringSlice slice)
         {
             var startPosition = slice.Start;
-            if (TryParse(ref slice, out HtmlAttributes attributes))
+            if (TryParse(ref slice, out HtmlAttributes? attributes))
             {
                 var inline = processor.Inline;
 
@@ -45,16 +47,16 @@ namespace Markdig.Extensions.GenericAttributes
                         }
                     }
                 }
-                var objectToAttach = inline is null || inline == processor.Root ? (MarkdownObject)processor.Block : inline;
+                var objectToAttach = inline is null || inline == processor.Root ? (MarkdownObject)processor.Block! : inline;
 
                 // If the current block is a Paragraph, but only the HtmlAttributes is used,
                 // Try to attach the attributes to the following block
                 if (objectToAttach is ParagraphBlock paragraph &&
-                    paragraph.Inline.FirstChild == null &&
-                    processor.Inline == null &&
+                    paragraph.Inline!.FirstChild is null &&
+                    processor.Inline is null &&
                     slice.IsEmptyOrWhitespace())
                 {
-                    var parent = paragraph.Parent;
+                    var parent = paragraph.Parent!;
                     var indexOfParagraph = parent.IndexOf(paragraph);
                     if (indexOfParagraph + 1 < parent.Count)
                     {
@@ -86,7 +88,7 @@ namespace Markdig.Extensions.GenericAttributes
         /// <param name="slice">The slice to parse.</param>
         /// <param name="attributes">The output attributes or null if not found or invalid</param>
         /// <returns><c>true</c> if parsing the HTML attributes was successful</returns>
-        public static bool TryParse(ref StringSlice slice, out HtmlAttributes attributes)
+        public static bool TryParse(ref StringSlice slice, [NotNullWhen(true)] out HtmlAttributes? attributes)
         {
             attributes = null;
             if (slice.PeekCharExtra(-1) == '{')
@@ -96,9 +98,9 @@ namespace Markdig.Extensions.GenericAttributes
 
             var line = slice;
 
-            string id = null;
-            List<string> classes = null;
-            List<KeyValuePair<string, string>> properties = null;
+            string? id = null;
+            List<string>? classes = null;
+            List<KeyValuePair<string, string?>>? properties = null;
 
             bool isValid = false;
             var c = line.NextChar();
@@ -175,12 +177,10 @@ namespace Markdig.Extensions.GenericAttributes
                     // Handle boolean properties that are not followed by =
                     if ((hasSpace && (c == '.' || c == '#' || IsStartAttributeName(c))) || c == '}')
                     {
-                        if (properties == null)
-                        {
-                            properties = new List<KeyValuePair<string, string>>();
-                        }
+                        properties ??= new ();
+                        
                         // Add a null value for the property
-                        properties.Add(new KeyValuePair<string, string>(name, null));
+                        properties.Add(new KeyValuePair<string, string?>(name, null));
                         continue;
                     }
 
@@ -245,11 +245,8 @@ namespace Markdig.Extensions.GenericAttributes
 
                     var value = slice.Text.Substring(startValue, endValue - startValue + 1);
 
-                    if (properties == null)
-                    {
-                        properties = new List<KeyValuePair<string, string>>();
-                    }
-                    properties.Add(new KeyValuePair<string, string>(name, value));
+                    properties ??= new();
+                    properties.Add(new KeyValuePair<string, string?>(name, value));
                     continue;
                 }
 

--- a/src/Markdig/Extensions/Globalization/GlobalizationExtension.cs
+++ b/src/Markdig/Extensions/Globalization/GlobalizationExtension.cs
@@ -67,7 +67,7 @@ namespace Markdig.Extensions.Globalization
             }
             else if (item is LeafBlock leaf)
             {
-                return ShouldBeRightToLeft(leaf.Inline);
+                return ShouldBeRightToLeft(leaf.Inline!);
             }
             else if (item is LiteralInline literal)
             {
@@ -76,7 +76,7 @@ namespace Markdig.Extensions.Globalization
 
             foreach (var paragraph in item.Descendants<ParagraphBlock>())
             {
-                foreach (var inline in paragraph.Inline)
+                foreach (var inline in paragraph.Inline!)
                 {
                     if (inline is LiteralInline literal)
                     {

--- a/src/Markdig/Extensions/MediaLinks/HostProviderBuilder.cs
+++ b/src/Markdig/Extensions/MediaLinks/HostProviderBuilder.cs
@@ -56,7 +56,7 @@ namespace Markdig.Extensions.MediaLinks
         {
             if (string.IsNullOrEmpty(hostPrefix))
                 ThrowHelper.ArgumentException("hostPrefix is null or empty.", nameof(hostPrefix));
-            if (handler == null)
+            if (handler is null)
                 ThrowHelper.ArgumentNullException(nameof(handler));
 
             return new DelegateProvider(hostPrefix, handler, allowFullScreen, iframeClass);
@@ -137,7 +137,7 @@ namespace Markdig.Extensions.MediaLinks
             string? trackKeyword = items.Skip(2).FirstOrDefault();
             string? trackId = items.Skip(3).FirstOrDefault();
 
-            if (albumKeyword != "album" || albumId == null || trackKeyword != "track" || trackId == null)
+            if (albumKeyword != "album" || albumId is null || trackKeyword != "track" || trackId is null)
             {
                 return null;
             }

--- a/src/Markdig/Extensions/MediaLinks/HostProviderBuilder.cs
+++ b/src/Markdig/Extensions/MediaLinks/HostProviderBuilder.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using System;
 using System.Collections.Generic;

--- a/src/Markdig/Extensions/MediaLinks/IHostProvider.cs
+++ b/src/Markdig/Extensions/MediaLinks/IHostProvider.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 

--- a/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
+++ b/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
@@ -48,7 +48,7 @@ namespace Markdig.Extensions.MediaLinks
 
         private bool TryLinkInlineRenderer(HtmlRenderer renderer, LinkInline linkInline)
         {
-            if (!linkInline.IsImage || linkInline.Url == null)
+            if (!linkInline.IsImage || linkInline.Url is null)
             {
                 return false;
             }

--- a/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
+++ b/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using Markdig.Renderers;
 using Markdig.Renderers.Html;

--- a/src/Markdig/Extensions/PragmaLines/PragmaLineExtension.cs
+++ b/src/Markdig/Extensions/PragmaLines/PragmaLineExtension.cs
@@ -36,7 +36,7 @@ namespace Markdig.Extensions.PragmaLines
         {
             var attribute = block.GetAttributes();
             var pragmaId = GetPragmaId(block);
-            if ( attribute.Id == null)
+            if ( attribute.Id is null)
             {
                 attribute.Id = pragmaId;
             }

--- a/src/Markdig/Extensions/PragmaLines/PragmaLineExtension.cs
+++ b/src/Markdig/Extensions/PragmaLines/PragmaLineExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Copyright (c) Alexandre Mutel. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
@@ -49,8 +49,7 @@ namespace Markdig.Extensions.PragmaLines
                 var tag = $"<a id=\"{pragmaId}\"></a>";
                 if (heading?.Inline?.FirstChild != null)
                 {
-                    heading.Inline.FirstChild.InsertBefore(new HtmlInline() { Tag = tag });
-
+                    heading.Inline.FirstChild.InsertBefore(new HtmlInline(tag));
                 }
                 else
                 {

--- a/src/Markdig/Extensions/ReferralLinks/ReferralLinksExtension.cs
+++ b/src/Markdig/Extensions/ReferralLinks/ReferralLinksExtension.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using System.Linq;
 using Markdig.Renderers;

--- a/src/Markdig/Extensions/SelfPipeline/SelfPipelineExtension.cs
+++ b/src/Markdig/Extensions/SelfPipeline/SelfPipelineExtension.cs
@@ -77,7 +77,7 @@ namespace Markdig.Extensions.SelfPipeline
         /// <exception cref="ArgumentNullException"></exception>
         public MarkdownPipeline CreatePipelineFromInput(string inputText)
         {
-            if (inputText == null) ThrowHelper.ArgumentNullException(nameof(inputText));
+            if (inputText is null) ThrowHelper.ArgumentNullException(nameof(inputText));
 
             var builder = new MarkdownPipelineBuilder();
             string? defaultConfig = DefaultExtensions;

--- a/src/Markdig/Extensions/SelfPipeline/SelfPipelineExtension.cs
+++ b/src/Markdig/Extensions/SelfPipeline/SelfPipelineExtension.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using Markdig.Helpers;
 using Markdig.Renderers;

--- a/src/Markdig/Extensions/SmartyPants/HtmlSmartyPantRenderer.cs
+++ b/src/Markdig/Extensions/SmartyPants/HtmlSmartyPantRenderer.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using Markdig.Renderers;
 using Markdig.Renderers.Html;

--- a/src/Markdig/Extensions/SmartyPants/SmartyPantOptions.cs
+++ b/src/Markdig/Extensions/SmartyPants/SmartyPantOptions.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Collections.Generic;
 
 namespace Markdig.Extensions.SmartyPants

--- a/src/Markdig/Extensions/SmartyPants/SmartyPantsExtension.cs
+++ b/src/Markdig/Extensions/SmartyPants/SmartyPantsExtension.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Parsers.Inlines;
 using Markdig.Renderers;
 

--- a/src/Markdig/Extensions/SmartyPants/SmartyPantsInlineParser.cs
+++ b/src/Markdig/Extensions/SmartyPants/SmartyPantsInlineParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Markdig.Helpers;
 using Markdig.Parsers;

--- a/src/Markdig/Extensions/Tables/GridTableParser.cs
+++ b/src/Markdig/Extensions/Tables/GridTableParser.cs
@@ -55,7 +55,7 @@ namespace Markdig.Extensions.Tables
                 c = line.CurrentChar;
             }
 
-            if (c != 0 || tableState == null)
+            if (c != 0 || tableState is null)
             {
                 return BlockState.None;
             }
@@ -196,7 +196,7 @@ namespace Markdig.Extensions.Tables
                 }
 
                 // Renew the block parser processor (or reset it for the last row)
-                if (columnSlice.BlockProcessor != null && (columnSlice.CurrentCell == null || columnSlice.CurrentCell.AllowClose))
+                if (columnSlice.BlockProcessor != null && (columnSlice.CurrentCell is null || columnSlice.CurrentCell.AllowClose))
                 {
                     columnSlice.BlockProcessor.ReleaseChild();
                     columnSlice.BlockProcessor = isLastRow ? null : processor.CreateChild();
@@ -265,7 +265,7 @@ namespace Markdig.Extensions.Tables
 
                 if (!isRowLine || !IsRowSeperator(sliceForCell))
                 {
-                    if (columnSlice.CurrentCell == null)
+                    if (columnSlice.CurrentCell is null)
                     {
                         columnSlice.CurrentCell = new TableCell(this)
                         {
@@ -273,7 +273,7 @@ namespace Markdig.Extensions.Tables
                             ColumnIndex = i
                         };
 
-                        if (columnSlice.BlockProcessor == null)
+                        if (columnSlice.BlockProcessor is null)
                         {
                             columnSlice.BlockProcessor = processor.CreateChild();
                         }

--- a/src/Markdig/Extensions/Tables/GridTableState.cs
+++ b/src/Markdig/Extensions/Tables/GridTableState.cs
@@ -33,7 +33,7 @@ namespace Markdig.Extensions.Tables
 
         public void AddLine(ref StringSlice line)
         {
-            if (Lines.Lines == null)
+            if (Lines.Lines is null)
             {
                 Lines = new StringLineGroup(4);
             }

--- a/src/Markdig/Extensions/Tables/GridTableState.cs
+++ b/src/Markdig/Extensions/Tables/GridTableState.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Markdig.Helpers;
 using Markdig.Parsers;

--- a/src/Markdig/Extensions/Tables/PipeTableBlockParser.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableBlockParser.cs
@@ -29,7 +29,7 @@ namespace Markdig.Extensions.Tables
         {
             // Only if we have already a paragraph
             var paragraph = processor.CurrentBlock as ParagraphBlock;
-            if (processor.IsCodeIndent || paragraph  == null)
+            if (processor.IsCodeIndent || paragraph  is null)
             {
                 return BlockState.None;
             }

--- a/src/Markdig/Extensions/Tables/PipeTableExtension.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableExtension.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Parsers.Inlines;
 using Markdig.Renderers;
 

--- a/src/Markdig/Extensions/Tables/PipeTableParser.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Markdig/Extensions/Tables/PipeTableParser.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableParser.cs
@@ -74,7 +74,7 @@ namespace Markdig.Extensions.Tables
                     return false;
                 }
 
-                if (processor.Inline == null)
+                if (processor.Inline is null)
                 {
                     isFirstLineEmpty = true;
                 }
@@ -197,7 +197,7 @@ namespace Markdig.Extensions.Tables
             state.ParserStates[Index] = null!;
 
             // Continue
-            if (tableState == null || container == null || tableState.IsInvalidTable || !tableState.LineHasPipe ) //|| tableState.LineIndex != state.LocalLineIndex)
+            if (tableState is null || container is null || tableState.IsInvalidTable || !tableState.LineHasPipe ) //|| tableState.LineIndex != state.LocalLineIndex)
             {
                 return true;
             }
@@ -207,7 +207,7 @@ namespace Markdig.Extensions.Tables
             // TODO: we could optimize this by merging FindHeaderRow and the cell loop
             var aligns = FindHeaderRow(delimiters);
 
-            if (Options.RequireHeaderSeparator && aligns == null)
+            if (Options.RequireHeaderSeparator && aligns is null)
             {
                 return true;
             }
@@ -293,7 +293,7 @@ namespace Markdig.Extensions.Tables
                 var pipeSeparator = delimiter as PipeTableDelimiterInline;
                 var isLine = delimiter is LineBreakInline;
 
-                if (row == null)
+                if (row is null)
                 {
                     row = new TableRow();
 
@@ -302,7 +302,7 @@ namespace Markdig.Extensions.Tables
                     // If the first delimiter is a pipe and doesn't have any parent or previous sibling, for cases like:
                     // 0)  | a | b | \n
                     // 1)  | a | b \n
-                    if (pipeSeparator != null && (delimiter.PreviousSibling == null || delimiter.PreviousSibling is LineBreakInline))
+                    if (pipeSeparator != null && (delimiter.PreviousSibling is null || delimiter.PreviousSibling is LineBreakInline))
                     {
                         delimiter.Remove();
                         continue;
@@ -321,7 +321,7 @@ namespace Markdig.Extensions.Tables
                 {
                     cellContentIt = cellContentIt.PreviousSibling ?? cellContentIt.Parent;
 
-                    if (cellContentIt == null || cellContentIt is LineBreakInline)
+                    if (cellContentIt is null || cellContentIt is LineBreakInline)
                     {
                         break;
                     }
@@ -330,7 +330,7 @@ namespace Markdig.Extensions.Tables
                     if (cellContentIt is PipeTableDelimiterInline || (cellContentIt.GetType() == typeof(ContainerInline) && cellContentIt.Parent is null ))
                     {
                         beginOfCell = ((ContainerInline)cellContentIt).FirstChild;
-                        if (endOfCell == null)
+                        if (endOfCell is null)
                         {
                             endOfCell = beginOfCell;
                         }
@@ -338,7 +338,7 @@ namespace Markdig.Extensions.Tables
                     }
 
                     beginOfCell = cellContentIt;
-                    if (endOfCell == null)
+                    if (endOfCell is null)
                     {
                         endOfCell = beginOfCell;
                     }
@@ -469,7 +469,7 @@ namespace Markdig.Extensions.Tables
         {
             align = 0;
             var literal = inline as LiteralInline;
-            if (literal == null)
+            if (literal is null)
             {
                 return false;
             }
@@ -525,7 +525,7 @@ namespace Markdig.Extensions.Tables
                     aligns.Add(new TableColumnDefinition() { Alignment =  align });
 
                     // If this is the last delimiter, we need to check the right side of the `|` delimiter
-                    if (nextDelimiter == null)
+                    if (nextDelimiter is null)
                     {
                         var nextSibling = columnDelimiter != null
                             ? columnDelimiter.FirstChild
@@ -587,7 +587,7 @@ namespace Markdig.Extensions.Tables
                 }
                 previous = previous.PreviousSibling;
             }
-            return previous == null || IsLine(previous);
+            return previous is null || IsLine(previous);
         }
 
         private static void TrimStart(Inline? inline)

--- a/src/Markdig/Extensions/Tables/Table.cs
+++ b/src/Markdig/Extensions/Tables/Table.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Markdig.Parsers;
 using Markdig.Syntax;

--- a/src/Markdig/Extensions/Tables/TableCell.cs
+++ b/src/Markdig/Extensions/Tables/TableCell.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Parsers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Extensions/TaskLists/TaskListInlineParser.cs
+++ b/src/Markdig/Extensions/TaskLists/TaskListInlineParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Renderers.Html;

--- a/src/Markdig/Extensions/Yaml/YamlFrontMatterParser.cs
+++ b/src/Markdig/Extensions/Yaml/YamlFrontMatterParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Syntax;

--- a/src/Markdig/Helpers/CharHelper.cs
+++ b/src/Markdig/Helpers/CharHelper.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Globalization;
 using System.Collections.Generic;

--- a/src/Markdig/Helpers/CharNormalizer.cs
+++ b/src/Markdig/Helpers/CharNormalizer.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Collections.Generic;
 
 namespace Markdig.Helpers

--- a/src/Markdig/Helpers/CharacterMap.cs
+++ b/src/Markdig/Helpers/CharacterMap.cs
@@ -2,6 +2,8 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -27,7 +29,7 @@ namespace Markdig.Helpers
         /// <exception cref="ArgumentNullException"></exception>
         public CharacterMap(IEnumerable<KeyValuePair<char, T>> maps)
         {
-            if (maps == null) ThrowHelper.ArgumentNullException(nameof(maps));
+            if (maps is null) ThrowHelper.ArgumentNullException(nameof(maps));
             var charSet = new HashSet<char>();
             int maxChar = 0;
 
@@ -59,7 +61,7 @@ namespace Markdig.Helpers
                     asciiMap[openingChar] ??= state.Value;
                     isOpeningCharacter.Set(openingChar);
                 }
-                else if (!nonAsciiMap.ContainsKey(openingChar))
+                else if (!nonAsciiMap!.ContainsKey(openingChar))
                 {
                     nonAsciiMap[openingChar] = state.Value;
                 }

--- a/src/Markdig/Helpers/CompactPrefixTree.cs
+++ b/src/Markdig/Helpers/CompactPrefixTree.cs
@@ -280,7 +280,7 @@ namespace Markdig.Helpers
             }
             else
             {
-                if (_unicodeRootMap == null)
+                if (_unicodeRootMap is null)
                 {
                     _unicodeRootMap = new Dictionary<char, int>();
                 }
@@ -315,7 +315,7 @@ namespace Markdig.Helpers
         /// <param name="input">Matches to initialize the <see cref="CompactPrefixTree{TValue}"/> with. For best lookup performance, this collection should be sorted.</param>
         public CompactPrefixTree(ICollection<KeyValuePair<string, TValue>> input)
         {
-            if (input == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.input);
+            if (input is null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.input);
 
             Init(input.Count, input.Count * 2, input.Count * 2);
 
@@ -429,7 +429,7 @@ namespace Markdig.Helpers
         private bool TryInsert(in KeyValuePair<string, TValue> pair, InsertionBehavior behavior)
         {
             string key = pair.Key;
-            if (key == null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
+            if (key is null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
             if (key.Length == 0) ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.key, ExceptionReason.String_Empty);
             Debug.Assert(!string.IsNullOrEmpty(key));
 

--- a/src/Markdig/Helpers/CompactPrefixTree.cs
+++ b/src/Markdig/Helpers/CompactPrefixTree.cs
@@ -1,5 +1,8 @@
 // Copyright (c) Miha Zupan. All rights reserved.
 // This file is licensed under the BSD-Clause 2 license.
+
+#nullable disable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Markdig/Helpers/CustomArrayPool.cs
+++ b/src/Markdig/Helpers/CustomArrayPool.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Threading;
 
 namespace Markdig.Helpers

--- a/src/Markdig/Helpers/EntityHelper.cs
+++ b/src/Markdig/Helpers/EntityHelper.cs
@@ -31,8 +31,6 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/Markdig/Helpers/HtmlHelper.cs
+++ b/src/Markdig/Helpers/HtmlHelper.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Text;
 

--- a/src/Markdig/Helpers/HtmlHelper.cs
+++ b/src/Markdig/Helpers/HtmlHelper.cs
@@ -54,7 +54,7 @@ namespace Markdig.Helpers
 
         public static bool TryParseHtmlTag(ref StringSlice text, StringBuilder builder)
         {
-            if (builder == null) ThrowHelper.ArgumentNullException(nameof(builder));
+            if (builder is null) ThrowHelper.ArgumentNullException(nameof(builder));
             var c = text.CurrentChar;
             if (c != '<')
             {
@@ -500,7 +500,7 @@ namespace Markdig.Helpers
                 }
             }
 
-            if (sb == null || lastPos == 0)
+            if (sb is null || lastPos == 0)
                 return text;
 
             sb.Append(text, lastPos, text.Length - lastPos);

--- a/src/Markdig/Helpers/LinkHelper.cs
+++ b/src/Markdig/Helpers/LinkHelper.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;

--- a/src/Markdig/Helpers/LinkHelper.cs
+++ b/src/Markdig/Helpers/LinkHelper.cs
@@ -716,12 +716,12 @@ namespace Markdig.Helpers
             return isValid;
         }
 
-        public static bool TryParseUrl<T>(T text, out string? link) where T : ICharIterator
+        public static bool TryParseUrl<T>(T text, [NotNullWhen(true)] out string? link) where T : ICharIterator
         {
             return TryParseUrl(ref text, out link, out _);
         }
 
-        public static bool TryParseUrl<T>(ref T text, out string? link, out bool hasPointyBrackets, bool isAutoLink = false) where T : ICharIterator
+        public static bool TryParseUrl<T>(ref T text, [NotNullWhen(true)] out string? link, out bool hasPointyBrackets, bool isAutoLink = false) where T : ICharIterator
         {
             bool isValid = false;
             hasPointyBrackets = false;

--- a/src/Markdig/Helpers/ObjectCache.cs
+++ b/src/Markdig/Helpers/ObjectCache.cs
@@ -58,7 +58,7 @@ namespace Markdig.Helpers
         /// <exception cref="ArgumentNullException">if instance is null</exception>
         public void Release(T instance)
         {
-            if (instance == null) ThrowHelper.ArgumentNullException(nameof(instance));
+            if (instance is null) ThrowHelper.ArgumentNullException(nameof(instance));
             Reset(instance);
             lock (builders)
             {

--- a/src/Markdig/Helpers/OrderedList.cs
+++ b/src/Markdig/Helpers/OrderedList.cs
@@ -27,7 +27,7 @@ namespace Markdig.Helpers
 
         public bool InsertBefore<TItem>(T item) where TItem : T
         {
-            if (item == null) ThrowHelper.ArgumentNullException_item();
+            if (item is null) ThrowHelper.ArgumentNullException_item();
             for (int i = 0; i < Count; i++)
             {
                 if (this[i] is TItem)
@@ -87,7 +87,7 @@ namespace Markdig.Helpers
 
         public bool InsertAfter<TItem>(T item) where TItem : T
         {
-            if (item == null) ThrowHelper.ArgumentNullException_item();
+            if (item is null) ThrowHelper.ArgumentNullException_item();
             for (int i = 0; i < Count; i++)
             {
                 if (this[i] is TItem)

--- a/src/Markdig/Helpers/OrderedList.cs
+++ b/src/Markdig/Helpers/OrderedList.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 

--- a/src/Markdig/Helpers/StringBuilderCache.cs
+++ b/src/Markdig/Helpers/StringBuilderCache.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Text;
 

--- a/src/Markdig/Helpers/StringLineGroup.cs
+++ b/src/Markdig/Helpers/StringLineGroup.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Markdig/Helpers/StringLineGroup.cs
+++ b/src/Markdig/Helpers/StringLineGroup.cs
@@ -47,7 +47,7 @@ namespace Markdig.Helpers
         /// <exception cref="ArgumentNullException"></exception>
         public StringLineGroup(string text)
         {
-            if (text == null) ThrowHelper.ArgumentNullException_text();
+            if (text is null) ThrowHelper.ArgumentNullException_text();
             Lines = new StringLine[1];
             Count = 0;
             Add(new StringSlice(text));

--- a/src/Markdig/Helpers/StringSlice.cs
+++ b/src/Markdig/Helpers/StringSlice.cs
@@ -83,7 +83,7 @@ namespace Markdig.Helpers
         /// <summary>
         /// The text of this slice.
         /// </summary>
-        public string Text;
+        public readonly string Text;
 
         /// <summary>
         /// Gets or sets the start position within <see cref="Text"/>.

--- a/src/Markdig/Helpers/StringSlice.cs
+++ b/src/Markdig/Helpers/StringSlice.cs
@@ -2,6 +2,8 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Runtime.CompilerServices;
 
@@ -81,7 +83,7 @@ namespace Markdig.Helpers
         /// <summary>
         /// The text of this slice.
         /// </summary>
-        public readonly string Text;
+        public string Text;
 
         /// <summary>
         /// Gets or sets the start position within <see cref="Text"/>.

--- a/src/Markdig/Markdig.targets
+++ b/src/Markdig/Markdig.targets
@@ -13,7 +13,8 @@
     <PackageIcon>markdig.png</PackageIcon>
     <PackageProjectUrl>https://github.com/lunet-io/markdig</PackageProjectUrl>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>9</LangVersion>
+    <Nullable>enable</Nullable>
     <!--Add support for sourcelink-->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/Markdig/Markdown.cs
+++ b/src/Markdig/Markdown.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.IO;
 using System.Reflection;

--- a/src/Markdig/MarkdownExtensions.cs
+++ b/src/Markdig/MarkdownExtensions.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using Markdig.Extensions.Abbreviations;
 using Markdig.Extensions.AutoIdentifiers;

--- a/src/Markdig/MarkdownPipeline.cs
+++ b/src/Markdig/MarkdownPipeline.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.IO;
 using System.Text;

--- a/src/Markdig/MarkdownPipelineBuilder.cs
+++ b/src/Markdig/MarkdownPipelineBuilder.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.IO;
 using Markdig.Helpers;

--- a/src/Markdig/MarkdownPipelineBuilder.cs
+++ b/src/Markdig/MarkdownPipelineBuilder.cs
@@ -110,7 +110,7 @@ namespace Markdig
             // Allow extensions to modify existing BlockParsers, InlineParsers and Renderer
             foreach (var extension in Extensions)
             {
-                if (extension == null)
+                if (extension is null)
                 {
                     ThrowHelper.InvalidOperationException("An extension cannot be null");
                 }

--- a/src/Markdig/Parsers/BlockParser.cs
+++ b/src/Markdig/Parsers/BlockParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Syntax;
 
 namespace Markdig.Parsers

--- a/src/Markdig/Parsers/BlockProcessor.cs
+++ b/src/Markdig/Parsers/BlockProcessor.cs
@@ -454,7 +454,7 @@ namespace Markdig.Parsers
         /// <exception cref="ArgumentException">The block must be opened</exception>
         public void Open(Block block)
         {
-            if (block == null) ThrowHelper.ArgumentNullException(nameof(block));
+            if (block is null) ThrowHelper.ArgumentNullException(nameof(block));
             if (!block.IsOpen) ThrowHelper.ArgumentException("The block must be opened", nameof(block));
             OpenedBlocks.Add(block);
         }
@@ -636,7 +636,7 @@ namespace Markdig.Parsers
             for (int i = OpenedBlocks.Count - 1; i >= 0; i--)
             {
                 var block = OpenedBlocks[i];
-                if (CurrentBlock == null)
+                if (CurrentBlock is null)
                 {
                     CurrentBlock = block;
                 }
@@ -923,7 +923,7 @@ namespace Markdig.Parsers
             {
                 var block = newBlocks.Pop();
 
-                if (block.Parser == null)
+                if (block.Parser is null)
                 {
                     ThrowHelper.InvalidOperationException($"The new block [{block.GetType()}] must have a valid Parser property");
                 }

--- a/src/Markdig/Parsers/BlockProcessor.cs
+++ b/src/Markdig/Parsers/BlockProcessor.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Markdig/Parsers/FencedBlockParserBase.cs
+++ b/src/Markdig/Parsers/FencedBlockParserBase.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 
 using Markdig.Helpers;

--- a/src/Markdig/Parsers/FencedCodeBlockParser.cs
+++ b/src/Markdig/Parsers/FencedCodeBlockParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Parsers/HeadingBlockParser.cs
+++ b/src/Markdig/Parsers/HeadingBlockParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Diagnostics;
 using Markdig.Helpers;
 using Markdig.Syntax;

--- a/src/Markdig/Parsers/HtmlBlockParser.cs
+++ b/src/Markdig/Parsers/HtmlBlockParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using Markdig.Helpers;
 using Markdig.Syntax;

--- a/src/Markdig/Parsers/IAttributesParseable.cs
+++ b/src/Markdig/Parsers/IAttributesParseable.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Parsers/IMarkdownParser.cs
+++ b/src/Markdig/Parsers/IMarkdownParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 namespace Markdig.Parsers
 {
     /// <summary>

--- a/src/Markdig/Parsers/IPostInlineProcessor.cs
+++ b/src/Markdig/Parsers/IPostInlineProcessor.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Parsers

--- a/src/Markdig/Parsers/IndentedCodeBlockParser.cs
+++ b/src/Markdig/Parsers/IndentedCodeBlockParser.cs
@@ -58,7 +58,7 @@ namespace Markdig.Parsers
         {
             if (!processor.IsCodeIndent || processor.IsBlankLine)
             {
-                if (block == null || !processor.IsBlankLine)
+                if (block is null || !processor.IsBlankLine)
                 {
                     if (block != null)
                     {
@@ -109,7 +109,7 @@ namespace Markdig.Parsers
         public override bool Close(BlockProcessor processor, Block block)
         {
             var codeBlock = (CodeBlock)block;
-            if (codeBlock == null)
+            if (codeBlock is null)
             {
                 return true;
             }

--- a/src/Markdig/Parsers/IndentedCodeBlockParser.cs
+++ b/src/Markdig/Parsers/IndentedCodeBlockParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Syntax;
 using System.Collections.Generic;

--- a/src/Markdig/Parsers/InlineParser.cs
+++ b/src/Markdig/Parsers/InlineParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 
 namespace Markdig.Parsers

--- a/src/Markdig/Parsers/InlineParserList.cs
+++ b/src/Markdig/Parsers/InlineParserList.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Collections.Generic;
 
 namespace Markdig.Parsers

--- a/src/Markdig/Parsers/InlineProcessor.cs
+++ b/src/Markdig/Parsers/InlineProcessor.cs
@@ -177,7 +177,7 @@ namespace Markdig.Parsers
         /// <param name="leafBlock">The leaf block.</param>
         public void ProcessInlineLeaf(LeafBlock leafBlock)
         {
-            if (leafBlock == null) ThrowHelper.ArgumentNullException_leafBlock();
+            if (leafBlock is null) ThrowHelper.ArgumentNullException_leafBlock();
 
             // clear parser states
             Array.Clear(ParserStates, 0, ParserStates.Length);
@@ -241,7 +241,7 @@ namespace Markdig.Parsers
                 var nextInline = Inline;
                 if (nextInline != null)
                 {
-                    if (nextInline.Parent == null)
+                    if (nextInline.Parent is null)
                     {
                         // Get deepest container
                         var container = FindLastContainer();

--- a/src/Markdig/Parsers/InlineProcessor.cs
+++ b/src/Markdig/Parsers/InlineProcessor.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Markdig/Parsers/Inlines/AutolinkInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/AutolinkInlineParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
@@ -54,9 +52,8 @@ namespace Markdig.Parsers.Inlines
                     return false;
                 }
 
-                processor.Inline = new HtmlInline()
+                processor.Inline = new HtmlInline(htmlTag)
                 {
-                    Tag = htmlTag,
                     Span = new SourceSpan(processor.GetSourcePosition(saved.Start, out line, out column), processor.GetSourcePosition(slice.Start - 1)),
                     Line = line,
                     Column = column

--- a/src/Markdig/Parsers/Inlines/CodeInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/CodeInlineParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;

--- a/src/Markdig/Parsers/Inlines/EmphasisDescriptor.cs
+++ b/src/Markdig/Parsers/Inlines/EmphasisDescriptor.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 
 namespace Markdig.Parsers.Inlines

--- a/src/Markdig/Parsers/Inlines/EmphasisInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/EmphasisInlineParser.cs
@@ -141,7 +141,7 @@ namespace Markdig.Parsers.Inlines
             // The amount of delimiter characters in the delimiter run may exceed emphasisDesc.MaximumCount, as that is handeled in `ProcessEmphasis`
 
             var delimiterChar = slice.CurrentChar;
-            var emphasisDesc = emphasisMap![delimiterChar];
+            var emphasisDesc = emphasisMap![delimiterChar]!;
 
             char pc = (char)0;
             if (processor.Inline is HtmlEntityInline htmlEntityInline)
@@ -220,8 +220,8 @@ namespace Markdig.Parsers.Inlines
             {
                 var closeDelimiter = delimiters[i];
                 // Skip delimiters not supported by this instance
-                EmphasisDescriptor emphasisDesc = emphasisMap![closeDelimiter.DelimiterChar];
-                if (emphasisDesc == null)
+                EmphasisDescriptor? emphasisDesc = emphasisMap![closeDelimiter.DelimiterChar];
+                if (emphasisDesc is null)
                 {
                     continue;
                 }

--- a/src/Markdig/Parsers/Inlines/EmphasisInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/EmphasisInlineParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Markdig/Parsers/Inlines/EmphasisInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/EmphasisInlineParser.cs
@@ -116,7 +116,7 @@ namespace Markdig.Parsers.Inlines
                 }
                 if (child is EmphasisDelimiterInline delimiter)
                 {
-                    if (delimiters == null)
+                    if (delimiters is null)
                     {
                         delimiters = inlinesCache.Get();
                     }
@@ -270,7 +270,7 @@ namespace Markdig.Parsers.Inlines
                                     emphasis = CreateEmphasisInline?.Invoke(closeDelimiter.DelimiterChar, isStrong: delimiterDelta == 2);
                                     #pragma warning restore CS0618 // Support fields marked as obsolete
                                 }
-                                if (emphasis == null)
+                                if (emphasis is null)
                                 {
                                     // Go in backwards order to give priority to newer delegates
                                     for (int delegateIndex = TryCreateEmphasisInlineList.Count - 1; delegateIndex >= 0; delegateIndex--)
@@ -279,7 +279,7 @@ namespace Markdig.Parsers.Inlines
                                         if (emphasis != null) break;
                                     }
 
-                                    if (emphasis == null)
+                                    if (emphasis is null)
                                     {
                                         emphasis = new EmphasisInline()
                                         {

--- a/src/Markdig/Parsers/Inlines/EscapeInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/EscapeInlineParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Syntax.Inlines;
 

--- a/src/Markdig/Parsers/Inlines/HtmlEntityParser.cs
+++ b/src/Markdig/Parsers/Inlines/HtmlEntityParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 

--- a/src/Markdig/Parsers/Inlines/LineBreakInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LineBreakInlineParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;

--- a/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;

--- a/src/Markdig/Parsers/Inlines/LiteralInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LiteralInlineParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;

--- a/src/Markdig/Parsers/ListBlockParser.cs
+++ b/src/Markdig/Parsers/ListBlockParser.cs
@@ -41,7 +41,7 @@ namespace Markdig.Parsers
 
             foreach (var itemParser in ItemParsers)
             {
-                if (itemParser.OpeningCharacters == null)
+                if (itemParser.OpeningCharacters is null)
                 {
                     ThrowHelper.InvalidOperationException($"The list item parser of type [{itemParser.GetType()}] cannot have OpeningCharacters to null. It must define a list of valid opening characters");
                 }
@@ -199,7 +199,7 @@ namespace Markdig.Parsers
 
             var c = state.CurrentChar;
             var itemParser = mapItemParsers![c];
-            if (itemParser == null)
+            if (itemParser is null)
             {
                 return BlockState.None;
             }
@@ -304,7 +304,7 @@ namespace Markdig.Parsers
                 }
             }
 
-            if (currentParent == null)
+            if (currentParent is null)
             {
                 var newList = new ListBlock(this)
                 {

--- a/src/Markdig/Parsers/ListBlockParser.cs
+++ b/src/Markdig/Parsers/ListBlockParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Markdig.Helpers;
 using Markdig.Syntax;

--- a/src/Markdig/Parsers/ListInfo.cs
+++ b/src/Markdig/Parsers/ListInfo.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 
 namespace Markdig.Parsers

--- a/src/Markdig/Parsers/ListItemParser.cs
+++ b/src/Markdig/Parsers/ListItemParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 namespace Markdig.Parsers
 {
     /// <summary>

--- a/src/Markdig/Parsers/MarkdownParser.cs
+++ b/src/Markdig/Parsers/MarkdownParser.cs
@@ -77,7 +77,7 @@ namespace Markdig.Parsers
         /// <exception cref="ArgumentNullException">if reader variable is null</exception>
         public static MarkdownDocument Parse(string text, MarkdownPipeline? pipeline = null, MarkdownParserContext? context = null)
         {
-            if (text == null) ThrowHelper.ArgumentNullException_text();
+            if (text is null) ThrowHelper.ArgumentNullException_text();
             pipeline ??= new MarkdownPipelineBuilder().Build();
 
             // Perform the parsing

--- a/src/Markdig/Parsers/MarkdownParser.cs
+++ b/src/Markdig/Parsers/MarkdownParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Markdig.Helpers;

--- a/src/Markdig/Parsers/NumberedListItemParser.cs
+++ b/src/Markdig/Parsers/NumberedListItemParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 
 namespace Markdig.Parsers

--- a/src/Markdig/Parsers/ParagraphBlockParser.cs
+++ b/src/Markdig/Parsers/ParagraphBlockParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Parsers/ParserBase.cs
+++ b/src/Markdig/Parsers/ParserBase.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 namespace Markdig.Parsers
 {
     /// <summary>

--- a/src/Markdig/Parsers/ParserList.cs
+++ b/src/Markdig/Parsers/ParserList.cs
@@ -102,7 +102,7 @@ namespace Markdig.Parsers
         /// <param name="openingChar">The opening character.</param>
         /// <returns>A list of parsers valid for the specified opening character or null if no parsers registered.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public T[] GetParsersForOpeningCharacter(uint openingChar)
+        public T[]? GetParsersForOpeningCharacter(uint openingChar)
         {
             return charMap[openingChar];
         }

--- a/src/Markdig/Parsers/ParserList.cs
+++ b/src/Markdig/Parsers/ParserList.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Markdig.Helpers;

--- a/src/Markdig/Parsers/QuoteBlockParser.cs
+++ b/src/Markdig/Parsers/QuoteBlockParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Parsers/ThematicBreakParser.cs
+++ b/src/Markdig/Parsers/ThematicBreakParser.cs
@@ -74,8 +74,8 @@ namespace Markdig.Parsers
             var isSetexHeading = previousParagraph != null && breakChar == '-' && !hasInnerSpaces;
             if (isSetexHeading)
             {
-                var parent = previousParagraph.Parent;
-                if (previousParagraph.Column != processor.Column && (parent is QuoteBlock || parent is ListItemBlock))
+                var parent = previousParagraph!.Parent!;
+                if (previousParagraph.Column != processor.Column && (parent is QuoteBlock or ListItemBlock))
                 {
                     isSetexHeading = false;
                 }

--- a/src/Markdig/Parsers/ThematicBreakParser.cs
+++ b/src/Markdig/Parsers/ThematicBreakParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Parsers/UnorderedListItemParser.cs
+++ b/src/Markdig/Parsers/UnorderedListItemParser.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 namespace Markdig.Parsers
 {
     /// <summary>

--- a/src/Markdig/Renderers/Html/HtmlAttributes.cs
+++ b/src/Markdig/Renderers/Html/HtmlAttributes.cs
@@ -104,7 +104,7 @@ namespace Markdig.Renderers.Html
         /// <exception cref="ArgumentNullException"></exception>
         public void CopyTo(HtmlAttributes htmlAttributes, bool mergeIdAndProperties = false, bool shared = true)
         {
-            if (htmlAttributes == null) ThrowHelper.ArgumentNullException(nameof(htmlAttributes));
+            if (htmlAttributes is null) ThrowHelper.ArgumentNullException(nameof(htmlAttributes));
             // Add html htmlAttributes to the object
             if (!mergeIdAndProperties || Id != null)
             {
@@ -119,7 +119,7 @@ namespace Markdig.Renderers.Html
                 htmlAttributes.Classes.AddRange(Classes);
             }
 
-            if (htmlAttributes.Properties == null)
+            if (htmlAttributes.Properties is null)
             {
                 htmlAttributes.Properties = shared ? Properties : Properties != null ? new (Properties) : null;
             }

--- a/src/Markdig/Renderers/Html/HtmlAttributes.cs
+++ b/src/Markdig/Renderers/Html/HtmlAttributes.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/Markdig/Renderers/Html/Inlines/AutolinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/AutolinkInlineRenderer.cs
@@ -21,7 +21,7 @@ namespace Markdig.Renderers.Html.Inlines
         {
             get
             {
-                return Rel.Contains("nofollow");
+                return Rel is not null && Rel.Contains("nofollow");
             }
             set
             {
@@ -40,7 +40,7 @@ namespace Markdig.Renderers.Html.Inlines
         /// <summary>
         /// Gets or sets the literal string in property rel for links
         /// </summary>
-        public string Rel { get; set; }
+        public string? Rel { get; set; }
 
         protected override void Write(HtmlRenderer renderer, AutolinkInline obj)
         {

--- a/src/Markdig/Renderers/Html/Inlines/CodeInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/CodeInlineRenderer.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Html.Inlines

--- a/src/Markdig/Renderers/Html/Inlines/DelimiterInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/DelimiterInlineRenderer.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Html.Inlines

--- a/src/Markdig/Renderers/Html/Inlines/EmphasisInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/EmphasisInlineRenderer.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Syntax.Inlines;
 using System.Diagnostics;
 

--- a/src/Markdig/Renderers/Html/Inlines/LineBreakInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LineBreakInlineRenderer.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Html.Inlines

--- a/src/Markdig/Renderers/Html/Inlines/LinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LinkInlineRenderer.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Syntax.Inlines;
 using System;
 

--- a/src/Markdig/Renderers/Html/Inlines/LiteralInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LiteralInlineRenderer.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Syntax.Inlines;
 
 namespace Markdig.Renderers.Html.Inlines

--- a/src/Markdig/Renderers/HtmlRenderer.cs
+++ b/src/Markdig/Renderers/HtmlRenderer.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Globalization;
 using System.IO;

--- a/src/Markdig/Renderers/HtmlRenderer.cs
+++ b/src/Markdig/Renderers/HtmlRenderer.cs
@@ -404,7 +404,7 @@ namespace Markdig.Renderers
         /// <returns>This instance</returns>
         public HtmlRenderer WriteLeafRawLines(LeafBlock leafBlock, bool writeEndOfLines, bool escape, bool softEscape = false)
         {
-            if (leafBlock == null) ThrowHelper.ArgumentNullException_leafBlock();
+            if (leafBlock is null) ThrowHelper.ArgumentNullException_leafBlock();
             if (leafBlock.Lines.Lines != null)
             {
                 var lines = leafBlock.Lines;

--- a/src/Markdig/Renderers/MarkdownObjectRenderer.cs
+++ b/src/Markdig/Renderers/MarkdownObjectRenderer.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Syntax;
 

--- a/src/Markdig/Renderers/Normalize/Inlines/CodeInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/CodeInlineRenderer.cs
@@ -15,7 +15,7 @@ namespace Markdig.Renderers.Normalize.Inlines
         protected override void Write(NormalizeRenderer renderer, CodeInline obj)
         {
             var delimiterCount = 0;
-            for (var i = 0; i < obj.Content.Length; i++)
+            for (var i = 0; i < obj.Content!.Length; i++)
             {
                 var index = obj.Content.IndexOf(obj.Delimiter, i);
                 if (index == -1) break;

--- a/src/Markdig/Renderers/Normalize/Inlines/LinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/LinkInlineRenderer.cs
@@ -44,7 +44,7 @@ namespace Markdig.Renderers.Normalize.Inlines
                 {
                     renderer.Write('(').Write(link.Url);
 
-                    if (!string.IsNullOrEmpty(link.Title))
+                    if (link.Title is { Length: > 0 })
                     {
                         renderer.Write(" \"");
                         renderer.Write(link.Title.Replace(@"""", @"\"""));

--- a/src/Markdig/Renderers/Normalize/NormalizeRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/NormalizeRenderer.cs
@@ -71,7 +71,7 @@ namespace Markdig.Renderers.Normalize
         ///// <returns></returns>
         //public NormalizeRenderer WriteAttributes(MarkdownObject obj)
         //{
-        //    if (obj == null) throw new ArgumentNullException(nameof(obj));
+        //    if (obj is null) throw new ArgumentNullException(nameof(obj));
         //    return WriteAttributes(obj.TryGetAttributes());
         //}
 
@@ -82,7 +82,7 @@ namespace Markdig.Renderers.Normalize
         ///// <returns>This instance</returns>
         //public NormalizeRenderer WriteAttributes(HtmlAttributes attributes)
         //{
-        //    if (attributes == null)
+        //    if (attributes is null)
         //    {
         //        return this;
         //    }

--- a/src/Markdig/Renderers/Normalize/NormalizeRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/NormalizeRenderer.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.IO;
 using Markdig.Syntax;
 using Markdig.Renderers.Normalize.Inlines;

--- a/src/Markdig/Renderers/RendererBase.cs
+++ b/src/Markdig/Renderers/RendererBase.cs
@@ -86,7 +86,7 @@ namespace Markdig.Renderers
         /// <param name="containerInline">The container inline.</param>
         public void WriteChildren(ContainerInline containerInline)
         {
-            if (containerInline == null)
+            if (containerInline is null)
             {
                 return;
             }
@@ -101,7 +101,7 @@ namespace Markdig.Renderers
             while (inline != null)
             {
                 IsFirstInContainer = isFirst;
-                IsLastInContainer = inline.NextSibling == null;
+                IsLastInContainer = inline.NextSibling is null;
 
                 Write(inline);
                 inline = inline.NextSibling;
@@ -121,7 +121,7 @@ namespace Markdig.Renderers
         /// <param name="obj">The Markdown object to write to this renderer.</param>
         public void Write(MarkdownObject obj)
         {
-            if (obj == null)
+            if (obj is null)
             {
                 return;
             }

--- a/src/Markdig/Renderers/RendererBase.cs
+++ b/src/Markdig/Renderers/RendererBase.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Markdig.Helpers;

--- a/src/Markdig/Renderers/Roundtrip/Inlines/CodeInlineRenderer.cs
+++ b/src/Markdig/Renderers/Roundtrip/Inlines/CodeInlineRenderer.cs
@@ -16,7 +16,7 @@ namespace Markdig.Renderers.Roundtrip.Inlines
         {
             var delimiterRun = new string(obj.Delimiter, obj.DelimiterCount);
             renderer.Write(delimiterRun);
-            if (obj.Content.Length != 0)
+            if (obj.Content is { Length: > 0 })
             {
                 renderer.Write(obj.ContentWithTrivia);
             }

--- a/src/Markdig/Renderers/Roundtrip/RoundtripRenderer.cs
+++ b/src/Markdig/Renderers/Roundtrip/RoundtripRenderer.cs
@@ -53,7 +53,7 @@ namespace Markdig.Renderers.Roundtrip
         /// <returns>This instance</returns>
         public void WriteLeafRawLines(LeafBlock leafBlock)
         {
-            if (leafBlock == null) ThrowHelper.ArgumentNullException_leafBlock();
+            if (leafBlock is null) ThrowHelper.ArgumentNullException_leafBlock();
             if (leafBlock.Lines.Lines != null)
             {
                 var lines = leafBlock.Lines;
@@ -69,7 +69,7 @@ namespace Markdig.Renderers.Roundtrip
 
         public void RenderLinesBefore(Block block)
         {
-            if (block.LinesBefore == null)
+            if (block.LinesBefore is null)
             {
                 return;
             }
@@ -83,7 +83,7 @@ namespace Markdig.Renderers.Roundtrip
         public void RenderLinesAfter(Block block)
         {
             previousWasLine = true;
-            if (block.LinesAfter == null)
+            if (block.LinesAfter is null)
             {
                 return;
             }

--- a/src/Markdig/Renderers/TextRendererBase.cs
+++ b/src/Markdig/Renderers/TextRendererBase.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Markdig/Renderers/TextRendererBase.cs
+++ b/src/Markdig/Renderers/TextRendererBase.cs
@@ -43,7 +43,7 @@ namespace Markdig.Renderers
             get { return writer; }
             set
             {
-                if (value == null)
+                if (value is null)
                 {
                     ThrowHelper.ArgumentNullException(nameof(value));
                 }
@@ -158,13 +158,13 @@ namespace Markdig.Renderers
 
         public void PushIndent(string indent)
         {
-            if (indent == null) ThrowHelper.ArgumentNullException(nameof(indent));
+            if (indent is null) ThrowHelper.ArgumentNullException(nameof(indent));
             indents.Add(new Indent(indent));
         }
 
         public void PushIndent(IEnumerable<string> lineSpecific)
         {
-            if (indents == null) ThrowHelper.ArgumentNullException(nameof(indents));
+            if (indents is null) ThrowHelper.ArgumentNullException(nameof(indents));
             indents.Add(new Indent(lineSpecific));
 
             // ensure that indents are written to the output stream
@@ -256,7 +256,7 @@ namespace Markdig.Renderers
         /// <returns>This instance</returns>
         public T Write(string content, int offset, int length)
         {
-            if (content == null)
+            if (content is null)
             {
                 return (T) this;
             }

--- a/src/Markdig/Syntax/BlankLineBlock.cs
+++ b/src/Markdig/Syntax/BlankLineBlock.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 namespace Markdig.Syntax
 {
     /// <summary>

--- a/src/Markdig/Syntax/Block.cs
+++ b/src/Markdig/Syntax/Block.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Parsers;
 using System.Collections.Generic;

--- a/src/Markdig/Syntax/BlockExtensions.cs
+++ b/src/Markdig/Syntax/BlockExtensions.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 namespace Markdig.Syntax
 {
     /// <summary>

--- a/src/Markdig/Syntax/BlockExtensions.cs
+++ b/src/Markdig/Syntax/BlockExtensions.cs
@@ -43,7 +43,7 @@ namespace Markdig.Syntax
                     upperIndex = midIndex - 1;
             }
 
-            if (block == null)
+            if (block is null)
             {
                 return rootBlock;
             }

--- a/src/Markdig/Syntax/CharIteratorHelper.cs
+++ b/src/Markdig/Syntax/CharIteratorHelper.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 
 namespace Markdig.Syntax

--- a/src/Markdig/Syntax/ContainerBlock.cs
+++ b/src/Markdig/Syntax/ContainerBlock.cs
@@ -58,7 +58,7 @@ namespace Markdig.Syntax
 
         public void Add(Block item)
         {
-            if (item == null)
+            if (item is null)
                 ThrowHelper.ArgumentNullException_item();
 
             if (item.Parent != null)
@@ -128,7 +128,7 @@ namespace Markdig.Syntax
 
         public bool Remove(Block item)
         {
-            if (item == null)
+            if (item is null)
                 ThrowHelper.ArgumentNullException_item();
 
             for (int i = Count - 1; i >= 0; i--)
@@ -219,7 +219,7 @@ namespace Markdig.Syntax
             {
                 if ((uint)index >= (uint)Count) ThrowHelper.ThrowIndexOutOfRangeException();
 
-                if (value == null)
+                if (value is null)
                     ThrowHelper.ArgumentNullException_item();
 
                 if (value.Parent != null)

--- a/src/Markdig/Syntax/ContainerBlock.cs
+++ b/src/Markdig/Syntax/ContainerBlock.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Markdig/Syntax/FencedCodeBlock.cs
+++ b/src/Markdig/Syntax/FencedCodeBlock.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Parsers;
 

--- a/src/Markdig/Syntax/HtmlBlock.cs
+++ b/src/Markdig/Syntax/HtmlBlock.cs
@@ -16,7 +16,7 @@ namespace Markdig.Syntax
         /// Initializes a new instance of the <see cref="HtmlBlock"/> class.
         /// </summary>
         /// <param name="parser">The parser.</param>
-        public HtmlBlock(BlockParser parser) : base(parser)
+        public HtmlBlock(BlockParser? parser) : base(parser)
         {
         }
 

--- a/src/Markdig/Syntax/IBlock.cs
+++ b/src/Markdig/Syntax/IBlock.cs
@@ -26,12 +26,12 @@ namespace Markdig.Syntax
         /// <summary>
         /// Gets the parent of this container. May be null.
         /// </summary>
-        ContainerBlock Parent { get; }
+        ContainerBlock? Parent { get; }
 
         /// <summary>
         /// Gets the parser associated to this instance.
         /// </summary>
-        BlockParser Parser { get; }
+        BlockParser? Parser { get; }
 
         /// <summary>
         /// Gets or sets a value indicating whether this instance is still open.
@@ -51,12 +51,12 @@ namespace Markdig.Syntax
         /// <summary>
         /// Occurs when the process of inlines begin.
         /// </summary>
-        event ProcessInlineDelegate ProcessInlinesBegin;
+        event ProcessInlineDelegate? ProcessInlinesBegin;
 
         /// <summary>
         /// Occurs when the process of inlines ends for this instance.
         /// </summary>
-        event ProcessInlineDelegate ProcessInlinesEnd;
+        event ProcessInlineDelegate? ProcessInlinesEnd;
 
         /// <summary>
         /// Trivia occurring before this block

--- a/src/Markdig/Syntax/IFencedBlock.cs
+++ b/src/Markdig/Syntax/IFencedBlock.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Parsers;
 

--- a/src/Markdig/Syntax/IMarkdownObject.cs
+++ b/src/Markdig/Syntax/IMarkdownObject.cs
@@ -31,7 +31,7 @@ namespace Markdig.Syntax
         /// <param name="key">The key.</param>
         /// <returns>The associated data or null if none</returns>
         /// <exception cref="System.ArgumentNullException">if key is null</exception>
-        object GetData(object key);
+        object? GetData(object key);
 
         /// <summary>
         /// Removes the associated data for the specified key.

--- a/src/Markdig/Syntax/Inlines/CodeInline.cs
+++ b/src/Markdig/Syntax/Inlines/CodeInline.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using System.Diagnostics;
 

--- a/src/Markdig/Syntax/Inlines/ContainerInline.cs
+++ b/src/Markdig/Syntax/Inlines/ContainerInline.cs
@@ -174,7 +174,7 @@ namespace Markdig.Syntax.Inlines
         /// <exception cref="ArgumentNullException">If the container is null</exception>
         public void EmbraceChildrenBy(ContainerInline container)
         {
-            if (container == null) ThrowHelper.ArgumentNullException(nameof(container));
+            if (container is null) ThrowHelper.ArgumentNullException(nameof(container));
             var child = FirstChild;
             while (child != null)
             {
@@ -190,11 +190,11 @@ namespace Markdig.Syntax.Inlines
         protected override void OnChildInsert(Inline child)
         {
             // A child is inserted before the FirstChild
-            if (child.PreviousSibling == null && child.NextSibling == FirstChild)
+            if (child.PreviousSibling is null && child.NextSibling == FirstChild)
             {
                 FirstChild = child;
             }
-            else if (child.NextSibling == null && child.PreviousSibling == LastChild)
+            else if (child.NextSibling is null && child.PreviousSibling == LastChild)
             {
                 LastChild = child;
             }
@@ -246,7 +246,7 @@ namespace Markdig.Syntax.Inlines
 
             public Enumerator(ContainerInline container) : this()
             {
-                if (container == null) ThrowHelper.ArgumentNullException(nameof(container));
+                if (container is null) ThrowHelper.ArgumentNullException(nameof(container));
                 this.container = container;
                 currentChild = nextChild = container.FirstChild;
             }

--- a/src/Markdig/Syntax/Inlines/ContainerInline.cs
+++ b/src/Markdig/Syntax/Inlines/ContainerInline.cs
@@ -2,14 +2,12 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
-using Markdig.Helpers;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using Markdig.Helpers;
 
 namespace Markdig.Syntax.Inlines
 {

--- a/src/Markdig/Syntax/Inlines/DelimiterInline.cs
+++ b/src/Markdig/Syntax/Inlines/DelimiterInline.cs
@@ -17,7 +17,7 @@ namespace Markdig.Syntax.Inlines
     {
         protected DelimiterInline(InlineParser parser)
         {
-            if (parser == null) ThrowHelper.ArgumentNullException(nameof(parser));
+            if (parser is null) ThrowHelper.ArgumentNullException(nameof(parser));
             Parser = parser;
             IsActive = true;
         }

--- a/src/Markdig/Syntax/Inlines/HtmlInline.cs
+++ b/src/Markdig/Syntax/Inlines/HtmlInline.cs
@@ -13,6 +13,11 @@ namespace Markdig.Syntax.Inlines
     [DebuggerDisplay("{Tag}")]
     public class HtmlInline : LeafInline
     {
+        public HtmlInline(string tag)
+        {
+            Tag = tag;
+        }
+
         /// <summary>
         /// Gets or sets the full declaration of this tag.
         /// </summary>

--- a/src/Markdig/Syntax/Inlines/IInline.cs
+++ b/src/Markdig/Syntax/Inlines/IInline.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 namespace Markdig.Syntax.Inlines
 {
     /// <summary>

--- a/src/Markdig/Syntax/Inlines/Inline.cs
+++ b/src/Markdig/Syntax/Inlines/Inline.cs
@@ -45,7 +45,7 @@ namespace Markdig.Syntax.Inlines
         /// <exception cref="ArgumentException">Inline has already a parent</exception>
         public void InsertAfter(Inline next)
         {
-            if (next == null) ThrowHelper.ArgumentNullException(nameof(next));
+            if (next is null) ThrowHelper.ArgumentNullException(nameof(next));
             if (next.Parent != null)
             {
                 ThrowHelper.ArgumentException("Inline has already a parent", nameof(next));
@@ -76,7 +76,7 @@ namespace Markdig.Syntax.Inlines
         /// <exception cref="ArgumentException">Inline has already a parent</exception>
         public void InsertBefore(Inline previous)
         {
-            if (previous == null) ThrowHelper.ArgumentNullException(nameof(previous));
+            if (previous is null) ThrowHelper.ArgumentNullException(nameof(previous));
             if (previous.Parent != null)
             {
                 ThrowHelper.ArgumentException("Inline has already a parent", nameof(previous));
@@ -132,7 +132,7 @@ namespace Markdig.Syntax.Inlines
         /// <exception cref="ArgumentNullException">If inline is null</exception>
         public Inline ReplaceBy(Inline inline, bool copyChildren = true)
         {
-            if (inline == null) ThrowHelper.ArgumentNullException(nameof(inline));
+            if (inline is null) ThrowHelper.ArgumentNullException(nameof(inline));
 
             // Save sibling
             var parent = Parent;
@@ -274,7 +274,7 @@ namespace Markdig.Syntax.Inlines
         /// <exception cref="ArgumentNullException"></exception>
         public void DumpTo(TextWriter writer)
         {
-            if (writer == null) ThrowHelper.ArgumentNullException_writer();
+            if (writer is null) ThrowHelper.ArgumentNullException_writer();
             DumpTo(writer, 0);
         }
 
@@ -286,7 +286,7 @@ namespace Markdig.Syntax.Inlines
         /// <exception cref="ArgumentNullException">if writer is null</exception>
         public void DumpTo(TextWriter writer, int level)
         {
-            if (writer == null) ThrowHelper.ArgumentNullException_writer();
+            if (writer is null) ThrowHelper.ArgumentNullException_writer();
             for (int i = 0; i < level; i++)
             {
                 writer.Write(' ');

--- a/src/Markdig/Syntax/Inlines/Inline.cs
+++ b/src/Markdig/Syntax/Inlines/Inline.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Markdig/Syntax/Inlines/LinkDelimiterInline.cs
+++ b/src/Markdig/Syntax/Inlines/LinkDelimiterInline.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Parsers;
 

--- a/src/Markdig/Syntax/Inlines/LinkInline.cs
+++ b/src/Markdig/Syntax/Inlines/LinkInline.cs
@@ -53,7 +53,7 @@ namespace Markdig.Syntax.Inlines
         /// <summary>
         /// Gets or sets the label.
         /// </summary>
-        public string Label { get; set; }
+        public string? Label { get; set; }
 
         /// <summary>
         /// The label span
@@ -77,12 +77,12 @@ namespace Markdig.Syntax.Inlines
         /// <summary>
         /// Gets or sets the reference this link is attached to. May be null.
         /// </summary>
-        public LinkReferenceDefinition Reference { get; set; }
+        public LinkReferenceDefinition? Reference { get; set; }
 
         /// <summary>
         /// Gets or sets the label as matched against the <see cref="LinkReferenceDefinition"/>.
         /// </summary>
-        public string LinkRefDefLabel { get; set; }
+        public string? LinkRefDefLabel { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="LinkRefDefLabel"/> with trivia as matched against
@@ -108,7 +108,7 @@ namespace Markdig.Syntax.Inlines
         /// <summary>
         /// Gets or sets the URL.
         /// </summary>
-        public string Url { get; set; }
+        public string? Url { get; set; }
 
         /// <summary>
         /// The URL source span.
@@ -133,7 +133,7 @@ namespace Markdig.Syntax.Inlines
         /// Gets or sets the GetDynamicUrl delegate. If this property is set, 
         /// it is used instead of <see cref="Url"/> to get the Url from this instance.
         /// </summary>
-        public GetUrlDelegate GetDynamicUrl { get; set; }
+        public GetUrlDelegate? GetDynamicUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the character used to enclose the <see cref="Title"/>.
@@ -145,7 +145,7 @@ namespace Markdig.Syntax.Inlines
         /// <summary>
         /// Gets or sets the title.
         /// </summary>
-        public string Title { get; set; }
+        public string? Title { get; set; }
 
         /// <summary>
         /// The title source span.

--- a/src/Markdig/Syntax/Inlines/LiteralInline.cs
+++ b/src/Markdig/Syntax/Inlines/LiteralInline.cs
@@ -20,7 +20,7 @@ namespace Markdig.Syntax.Inlines
         /// </summary>
         public LiteralInline()
         {
-            Content = new StringSlice(null);
+            Content = new StringSlice(null!);
         }
 
         /// <summary>

--- a/src/Markdig/Syntax/Inlines/LiteralInline.cs
+++ b/src/Markdig/Syntax/Inlines/LiteralInline.cs
@@ -39,7 +39,7 @@ namespace Markdig.Syntax.Inlines
         /// <exception cref="ArgumentNullException"></exception>
         public LiteralInline(string text)
         {
-            if (text == null) ThrowHelper.ArgumentNullException_text();
+            if (text is null) ThrowHelper.ArgumentNullException_text();
             Content = new StringSlice(text);
         }
 

--- a/src/Markdig/Syntax/LeafBlock.cs
+++ b/src/Markdig/Syntax/LeafBlock.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Diagnostics;
 using Markdig.Helpers;
 using Markdig.Parsers;

--- a/src/Markdig/Syntax/LeafBlock.cs
+++ b/src/Markdig/Syntax/LeafBlock.cs
@@ -78,7 +78,7 @@ namespace Markdig.Syntax
         /// <param name="trackTrivia">Whether to keep track of trivia such as whitespace, extra heading characters and unescaped string values.</param>
         public void AppendLine(ref StringSlice slice, int column, int line, int sourceLinePosition, bool trackTrivia)
         {
-            if (Lines.Lines == null)
+            if (Lines.Lines is null)
             {
                 Lines = new StringLineGroup(4, ProcessInlines);
             }

--- a/src/Markdig/Syntax/LinkReferenceDefinition.cs
+++ b/src/Markdig/Syntax/LinkReferenceDefinition.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Diagnostics.CodeAnalysis;
 
 using Markdig.Helpers;

--- a/src/Markdig/Syntax/LinkReferenceDefinitionExtensions.cs
+++ b/src/Markdig/Syntax/LinkReferenceDefinitionExtensions.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System.Diagnostics.CodeAnalysis;
 
 using Markdig.Helpers;

--- a/src/Markdig/Syntax/LinkReferenceDefinitionExtensions.cs
+++ b/src/Markdig/Syntax/LinkReferenceDefinitionExtensions.cs
@@ -19,9 +19,9 @@ namespace Markdig.Syntax
 
         public static bool ContainsLinkReferenceDefinition(this MarkdownDocument document, string label)
         {
-            if (label == null) ThrowHelper.ArgumentNullException_label();
+            if (label is null) ThrowHelper.ArgumentNullException_label();
             var references = document.GetData(DocumentKey) as LinkReferenceDefinitionGroup;
-            if (references == null)
+            if (references is null)
             {
                 return false;
             }
@@ -37,10 +37,10 @@ namespace Markdig.Syntax
 
         public static bool TryGetLinkReferenceDefinition(this MarkdownDocument document, string label, [NotNullWhen(true)] out LinkReferenceDefinition? linkReferenceDefinition)
         {
-            if (label == null) ThrowHelper.ArgumentNullException_label();
+            if (label is null) ThrowHelper.ArgumentNullException_label();
             linkReferenceDefinition = null;
             var references = document.GetData(DocumentKey) as LinkReferenceDefinitionGroup;
-            if (references == null)
+            if (references is null)
             {
                 return false;
             }
@@ -50,7 +50,7 @@ namespace Markdig.Syntax
         public static LinkReferenceDefinitionGroup GetLinkReferenceDefinitions(this MarkdownDocument document, bool addGroup)
         {
             var references = document.GetData(DocumentKey) as LinkReferenceDefinitionGroup;
-            if (references == null)
+            if (references is null)
             {
                 references = new LinkReferenceDefinitionGroup();
                 document.SetData(DocumentKey, references);

--- a/src/Markdig/Syntax/LinkReferenceDefinitionGroup.cs
+++ b/src/Markdig/Syntax/LinkReferenceDefinitionGroup.cs
@@ -2,12 +2,10 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
-using Markdig.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Markdig.Helpers;
 
 namespace Markdig.Syntax
 {

--- a/src/Markdig/Syntax/ListBlock.cs
+++ b/src/Markdig/Syntax/ListBlock.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Parsers;
 
 namespace Markdig.Syntax

--- a/src/Markdig/Syntax/MarkdownDocument.cs
+++ b/src/Markdig/Syntax/MarkdownDocument.cs
@@ -28,6 +28,6 @@ namespace Markdig.Syntax
         /// Gets a list of zero-based indexes of line beginnings in the source span
         /// <para>Available if <see cref="MarkdownPipelineBuilder.PreciseSourceLocation"/> is used, otherwise null</para>
         /// </summary>
-        public List<int> LineStartIndexes;
+        public List<int>? LineStartIndexes { get; set; }
     }
 }

--- a/src/Markdig/Syntax/MarkdownObject.cs
+++ b/src/Markdig/Syntax/MarkdownObject.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 using Markdig.Helpers;
 

--- a/src/Markdig/Syntax/MarkdownObject.cs
+++ b/src/Markdig/Syntax/MarkdownObject.cs
@@ -106,7 +106,7 @@ namespace Markdig.Syntax
 
             public void SetData(object key, object value)
             {
-                if (key == null) ThrowHelper.ArgumentNullException_key();
+                if (key is null) ThrowHelper.ArgumentNullException_key();
 
                 DataEntry[] entries = _entries;
                 int count = _count;

--- a/src/Markdig/Syntax/NoBlocksFoundBlock.cs
+++ b/src/Markdig/Syntax/NoBlocksFoundBlock.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Parsers;
 
 namespace Markdig.Syntax

--- a/src/Markdig/Syntax/ParagraphBlock.cs
+++ b/src/Markdig/Syntax/ParagraphBlock.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Parsers;
 
 namespace Markdig.Syntax

--- a/src/Markdig/Syntax/QuoteBlock.cs
+++ b/src/Markdig/Syntax/QuoteBlock.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using Markdig.Helpers;
 using Markdig.Parsers;
 using System.Collections.Generic;

--- a/src/Markdig/Syntax/SourceSpan.cs
+++ b/src/Markdig/Syntax/SourceSpan.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable enable
-
 using System;
 
 namespace Markdig.Syntax


### PR DESCRIPTION
This PR completes the nullability annotations and enables nullable at the project level. 

There are 4 possibility breaking changes introduced to enforce initialization of non-nullable properties to the following classes.

HeadingLinkReferenceDefinition
FootnoteLink
FootnoteLinkReference
HtmlInline

While these classes have to be constructed with a non-null object, they remain fully mutable after construction to allow the DOM to be manipulated. 
