### PR TITLE
Cache the MarkdownParser & Processors

### DIFF
--- a/src/Markdig/Markdown.cs
+++ b/src/Markdig/Markdown.cs
@@ -21,14 +21,14 @@ namespace Markdig
     {
         public static readonly string Version = ((AssemblyFileVersionAttribute) typeof(Markdown).Assembly.GetCustomAttributes(typeof(AssemblyFileVersionAttribute), false)[0]).Version;
 
-        private static readonly MarkdownPipeline _defaultPipeline = new MarkdownPipelineBuilder().Build();
+        internal static readonly MarkdownPipeline DefaultPipeline = new MarkdownPipelineBuilder().Build();
         private static readonly MarkdownPipeline _defaultTrackTriviaPipeline = new MarkdownPipelineBuilder().EnableTrackTrivia().Build();
 
         private static MarkdownPipeline GetPipeline(MarkdownPipeline? pipeline, string markdown)
         {
             if (pipeline is null)
             {
-                return _defaultPipeline;
+                return DefaultPipeline;
             }
 
             var selfPipeline = pipeline.Extensions.Find<SelfPipelineExtension>();
@@ -111,7 +111,7 @@ namespace Markdig
         {
             if (document is null) ThrowHelper.ArgumentNullException(nameof(document));
 
-            pipeline ??= _defaultPipeline;
+            pipeline ??= DefaultPipeline;
 
             using var rentedRenderer = pipeline.RentHtmlRenderer();
             HtmlRenderer renderer = rentedRenderer.Instance;

--- a/src/Markdig/Parsers/BlockProcessor.cs
+++ b/src/Markdig/Parsers/BlockProcessor.cs
@@ -960,6 +960,7 @@ namespace Markdig.Parsers
         internal void Setup(MarkdownDocument document, BlockParserList parsers, MarkdownParserContext? context, bool trackTrivia)
         {
             if (document is null) ThrowHelper.ArgumentNullException(nameof(document));
+            if (parsers is null) ThrowHelper.ArgumentNullException(nameof(parsers));
 
             Document = document;
             Parsers = parsers;

--- a/src/Markdig/Polyfills/NullableAttributes.cs
+++ b/src/Markdig/Polyfills/NullableAttributes.cs
@@ -15,6 +15,14 @@ namespace System.Diagnostics.CodeAnalysis
 
         public bool ReturnValue { get; }
     }
-
 #endif
+
+    internal sealed class MemberNotNullAttribute : Attribute
+    {
+        public MemberNotNullAttribute(string member) => Members = new[] { member };
+
+        public MemberNotNullAttribute(params string[] members) => Members = members;
+
+        public string[] Members { get; }
+    }
 }

--- a/src/Markdig/Syntax/Block.cs
+++ b/src/Markdig/Syntax/Block.cs
@@ -128,9 +128,9 @@ namespace Markdig.Syntax
 
         internal static Block FindRootMostContainerParent(Block block)
         {
-            if (block.Parent is ContainerBlock && !(block.Parent is MarkdownDocument))
+            while (block.Parent is ContainerBlock && block.Parent is not MarkdownDocument)
             {
-                return FindRootMostContainerParent(block.Parent);
+                block = block.Parent;
             }
             return block;
         }


### PR DESCRIPTION
- `MarkdownParser` is made static (had private ctor before)
- `Block/InlineProcessor` got a set of Setup/Rent/Reset/Release methods



```c#
Markdown.Parse("Hello world!");
```


Before:
![image](https://user-images.githubusercontent.com/25307628/110969439-fd99ae00-8358-11eb-88c2-e9d44dd04ed5.png)

After:
![image](https://user-images.githubusercontent.com/25307628/110969571-1dc96d00-8359-11eb-9899-dd19df1e29b2.png)
