### PR TITLE
Improve Code Quality

### DIFF
--- a/src/Markdig/Extensions/CustomContainers/HtmlCustomContainerInlineRenderer.cs
+++ b/src/Markdig/Extensions/CustomContainers/HtmlCustomContainerInlineRenderer.cs
@@ -15,7 +15,7 @@ namespace Markdig.Extensions.CustomContainers
     {
         protected override void Write(HtmlRenderer renderer, CustomContainerInline obj)
         {
-            renderer.Write("<span").WriteAttributes(obj).Write(">");
+            renderer.Write("<span").WriteAttributes(obj).Write('>');
             renderer.WriteChildren(obj);
             renderer.Write("</span>");
         }

--- a/src/Markdig/Extensions/CustomContainers/HtmlCustomContainerRenderer.cs
+++ b/src/Markdig/Extensions/CustomContainers/HtmlCustomContainerRenderer.cs
@@ -18,7 +18,7 @@ namespace Markdig.Extensions.CustomContainers
             renderer.EnsureLine();
             if (renderer.EnableHtmlForBlock)
             {
-                renderer.Write("<div").WriteAttributes(obj).Write(">");
+                renderer.Write("<div").WriteAttributes(obj).Write('>');
             }
             // We don't escape a CustomContainer
             renderer.WriteChildren(obj);

--- a/src/Markdig/Extensions/DefinitionLists/HtmlDefinitionListRenderer.cs
+++ b/src/Markdig/Extensions/DefinitionLists/HtmlDefinitionListRenderer.cs
@@ -41,7 +41,7 @@ namespace Markdig.Extensions.DefinitionLists
                             hasOpendd = false;
                             countdd = 0;
                         }
-                        renderer.Write("<dt").WriteAttributes(definitionTerm).Write(">");
+                        renderer.Write("<dt").WriteAttributes(definitionTerm).Write('>');
                         renderer.WriteLeafInline(definitionTerm);
                         renderer.WriteLine("</dt>");
                     }
@@ -49,7 +49,7 @@ namespace Markdig.Extensions.DefinitionLists
                     {
                         if (!hasOpendd)
                         {
-                            renderer.Write("<dd").WriteAttributes(definitionItem).Write(">");
+                            renderer.Write("<dd").WriteAttributes(definitionItem).Write('>');
                             countdd = 0;
                             hasOpendd = true;
                         }

--- a/src/Markdig/Extensions/DefinitionLists/HtmlDefinitionListRenderer.cs
+++ b/src/Markdig/Extensions/DefinitionLists/HtmlDefinitionListRenderer.cs
@@ -17,7 +17,7 @@ namespace Markdig.Extensions.DefinitionLists
         protected override void Write(HtmlRenderer renderer, DefinitionList list)
         {
             renderer.EnsureLine();
-            renderer.Write("<dl").WriteAttributes(list).WriteLine(">");
+            renderer.Write("<dl").WriteAttributes(list).WriteLine('>');
             foreach (var item in list)
             {
                 bool hasOpendd = false;

--- a/src/Markdig/Extensions/Figures/HtmlFigureCaptionRenderer.cs
+++ b/src/Markdig/Extensions/Figures/HtmlFigureCaptionRenderer.cs
@@ -16,7 +16,7 @@ namespace Markdig.Extensions.Figures
         protected override void Write(HtmlRenderer renderer, FigureCaption obj)
         {
             renderer.EnsureLine();
-            renderer.Write("<figcaption").WriteAttributes(obj).Write(">");
+            renderer.Write("<figcaption").WriteAttributes(obj).Write('>');
             renderer.WriteLeafInline(obj);
             renderer.WriteLine("</figcaption>");
         }

--- a/src/Markdig/Extensions/Footnotes/Footnote.cs
+++ b/src/Markdig/Extensions/Footnotes/Footnote.cs
@@ -16,7 +16,6 @@ namespace Markdig.Extensions.Footnotes
     {
         public Footnote(BlockParser parser) : base(parser)
         {
-            Links = new List<FootnoteLink>();
             Order = -1;
         }
 
@@ -33,7 +32,7 @@ namespace Markdig.Extensions.Footnotes
         /// <summary>
         /// Gets the links referencing this footnote.
         /// </summary>
-        public List<FootnoteLink> Links { get; private set; }
+        public List<FootnoteLink> Links { get; } = new ();
 
         /// <summary>
         /// The label span

--- a/src/Markdig/Extensions/MediaLinks/HostProviderBuilder.cs
+++ b/src/Markdig/Extensions/MediaLinks/HostProviderBuilder.cs
@@ -92,8 +92,8 @@ namespace Markdig.Extensions.MediaLinks
             }
             var queryParams = SplitQuery(uri);
             return BuildYouTubeIframeUrl(
-                queryParams.FirstOrDefault(p => p.StartsWith("v="))?.Substring(2),
-                queryParams.FirstOrDefault(p => p.StartsWith("t="))?.Substring(2)
+                queryParams.FirstOrDefault(p => p.StartsWith("v=", StringComparison.Ordinal))?.Substring(2),
+                queryParams.FirstOrDefault(p => p.StartsWith("t=", StringComparison.Ordinal))?.Substring(2)
             );
         }
 
@@ -101,7 +101,7 @@ namespace Markdig.Extensions.MediaLinks
         {
             return BuildYouTubeIframeUrl(
                 uri.AbsolutePath.Substring(1),
-                SplitQuery(uri).FirstOrDefault(p => p.StartsWith("t="))?.Substring(2)
+                SplitQuery(uri).FirstOrDefault(p => p.StartsWith("t=", StringComparison.Ordinal))?.Substring(2)
             );
         }
 

--- a/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
+++ b/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
@@ -144,7 +144,7 @@ namespace Markdig.Extensions.MediaLinks
             var htmlAttributes = GetHtmlAttributes(linkInline);
             renderer.Write("<iframe src=\"");
             renderer.WriteEscapeUrl(iframeUrl);
-            renderer.Write("\"");
+            renderer.Write('"');
 
             if (!string.IsNullOrEmpty(Options.Width))
                 htmlAttributes.AddPropertyIfNotExist("width", Options.Width);

--- a/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
+++ b/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
@@ -57,7 +57,7 @@ namespace Markdig.Extensions.MediaLinks
             {
                 // see https://tools.ietf.org/html/rfc3986#section-4.2
                 // since relative uri doesn't support many properties, "http" is used as a placeholder here.
-                if (linkInline.Url.StartsWith("//") && Uri.TryCreate("http:" + linkInline.Url, UriKind.Absolute, out uri))
+                if (linkInline.Url.StartsWith("//", StringComparison.Ordinal) && Uri.TryCreate("http:" + linkInline.Url, UriKind.Absolute, out uri))
                 {
                     isSchemaRelative = true;
                 }
@@ -101,7 +101,7 @@ namespace Markdig.Extensions.MediaLinks
                 Options.ExtensionToMimeType.TryGetValue(path.Substring(lastDot), out string? mimeType))
             {
                 var htmlAttributes = GetHtmlAttributes(linkInline);
-                var isAudio = mimeType.StartsWith("audio");
+                var isAudio = mimeType.StartsWith("audio", StringComparison.Ordinal);
                 var tagType = isAudio ? "audio" : "video";
 
                 renderer.Write($"<{tagType}");

--- a/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
+++ b/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
@@ -18,7 +18,7 @@ namespace Markdig.Extensions.Tables
         protected override void Write(HtmlRenderer renderer, Table table)
         {
             renderer.EnsureLine();
-            renderer.Write("<table").WriteAttributes(table).WriteLine(">");
+            renderer.Write("<table").WriteAttributes(table).WriteLine('>');
 
             bool hasBody = false;
             bool hasAlreadyHeader = false;
@@ -109,7 +109,7 @@ namespace Markdig.Extensions.Tables
                         }
                     }
                     renderer.WriteAttributes(cell);
-                    renderer.Write(">");
+                    renderer.Write('>');
 
                     var previousImplicitParagraph = renderer.ImplicitParagraph;
                     if (cell.Count == 1)

--- a/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
+++ b/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
@@ -69,7 +69,7 @@ namespace Markdig.Extensions.Tables
                     renderer.WriteLine("<tbody>");
                     hasBody = true;
                 }
-                renderer.Write("<tr").WriteAttributes(row).WriteLine(">");
+                renderer.Write("<tr").WriteAttributes(row).WriteLine('>');
                 for (int i = 0; i < row.Count; i++)
                 {
                     var cellObj = row[i];

--- a/src/Markdig/Extensions/Tables/PipeTableParser.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableParser.cs
@@ -625,24 +625,17 @@ namespace Markdig.Extensions.Tables
 
         private sealed class TableState
         {
-            public TableState()
-            {
-                ColumnAndLineDelimiters = new List<Inline>();
-                Cells = new List<TableCell>();
-                EndOfLines = new List<Inline>();
-            }
-
             public bool IsInvalidTable { get; set; }
 
             public bool LineHasPipe { get; set; }
 
             public int LineIndex { get; set; }
 
-            public List<Inline> ColumnAndLineDelimiters { get; }
+            public List<Inline> ColumnAndLineDelimiters { get; } = new();
 
-            public List<TableCell> Cells { get; }
+            public List<TableCell> Cells { get; } = new();
 
-            public List<Inline> EndOfLines { get; }
+            public List<Inline> EndOfLines { get; } = new();
         }
     }
 }

--- a/src/Markdig/Extensions/Tables/Table.cs
+++ b/src/Markdig/Extensions/Tables/Table.cs
@@ -17,7 +17,7 @@ namespace Markdig.Extensions.Tables
         /// <summary>
         /// Initializes a new instance of the <see cref="Table"/> class.
         /// </summary>
-        public Table() : this(null)
+        public Table() : base(null)
         {
         }
 
@@ -27,13 +27,12 @@ namespace Markdig.Extensions.Tables
         /// <param name="parser">The parser used to create this block.</param>
         public Table(BlockParser? parser) : base(parser)
         {
-            ColumnDefinitions = new List<TableColumnDefinition>();
         }
 
         /// <summary>
         /// Gets or sets the column alignments. May be null.
         /// </summary>
-        public List<TableColumnDefinition> ColumnDefinitions { get; }
+        public List<TableColumnDefinition> ColumnDefinitions { get; } = new();
 
         /// <summary>
         /// Checks if the table structure is valid.

--- a/src/Markdig/Helpers/CharacterMap.cs
+++ b/src/Markdig/Helpers/CharacterMap.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -16,10 +14,10 @@ namespace Markdig.Helpers
     /// Allows to associate characters to a data structures and query efficiently for them.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class CharacterMap<T> where T : class
+    public sealed class CharacterMap<T> where T : class
     {
         private readonly T[] asciiMap;
-        private readonly Dictionary<uint, T> nonAsciiMap;
+        private readonly Dictionary<uint, T>? nonAsciiMap;
         private readonly BoolVector128 isOpeningCharacter;
 
         /// <summary>
@@ -78,7 +76,7 @@ namespace Markdig.Helpers
         /// </summary>
         /// <param name="openingChar">The opening character.</param>
         /// <returns>A list of parsers valid for the specified opening character or null if no parsers registered.</returns>
-        public T this[uint openingChar]
+        public T? this[uint openingChar]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -90,7 +88,7 @@ namespace Markdig.Helpers
                 }
                 else
                 {
-                    T map = null;
+                    T? map = null;
                     nonAsciiMap?.TryGetValue(openingChar, out map);
                     return map;
                 }
@@ -174,7 +172,7 @@ namespace Markdig.Helpers
                     for (int i = start; i <= end; i++)
                     {
                         char c = pText[i];
-                        if (c < 128 ? isOpeningCharacter[c] : nonAsciiMap.ContainsKey(c))
+                        if (c < 128 ? isOpeningCharacter[c] : nonAsciiMap!.ContainsKey(c))
                         {
                             return i;
                         }

--- a/src/Markdig/Helpers/CompactPrefixTree.cs
+++ b/src/Markdig/Helpers/CompactPrefixTree.cs
@@ -519,7 +519,7 @@ namespace Markdig.Helpers
                                 Debug.Assert(key.Length != previousKey.Length);
                                 if (previousKey.Length < key.Length) // If the input was sorted, this should be hit
                                 {
-                                    Debug.Assert(key.StartsWith(previousKey));
+                                    Debug.Assert(key.StartsWith(previousKey, StringComparison.Ordinal));
                                     node.ChildChar = key[i];
                                     node.MatchIndex = previousMatchIndex;
                                     EnsureTreeCapacity(TreeSize + 1);
@@ -533,7 +533,7 @@ namespace Markdig.Helpers
                                 else // if key.Length < previousKey.Length
                                 {
                                     Debug.Assert(key.Length < previousKey.Length);
-                                    Debug.Assert(previousKey.StartsWith(key));
+                                    Debug.Assert(previousKey.StartsWith(key, StringComparison.Ordinal));
                                     node.ChildChar = previousKey[i];
                                     node.MatchIndex = Count;
                                     EnsureTreeCapacity(TreeSize + 1);
@@ -583,7 +583,7 @@ namespace Markdig.Helpers
                         else
                         {
                             // This node has a child char, therefore we either don't have a match attached or that match is simply a prefix of the current key
-                            Debug.Assert(node.MatchIndex == -1 || key.StartsWith(_matches[node.MatchIndex].Key));
+                            Debug.Assert(node.MatchIndex == -1 || key.StartsWith(_matches[node.MatchIndex].Key, StringComparison.Ordinal));
 
                             // Set this pair as the current node's first element in the Children list
                             node.Children = _childrenIndex;
@@ -641,7 +641,7 @@ namespace Markdig.Helpers
                         // It's not a duplicate but shares key.Length characters, therefore it's longer
                         // This will never occur if the input was sorted
                         Debug.Assert(previousMatch.Key.Length > key.Length);
-                        Debug.Assert(previousMatch.Key.StartsWith(key));
+                        Debug.Assert(previousMatch.Key.StartsWith(key, StringComparison.Ordinal));
                         Debug.Assert(node.ChildChar == 0 && node.Children == -1);
 
                         // It is a leaf node

--- a/src/Markdig/Markdig.targets
+++ b/src/Markdig/Markdig.targets
@@ -6,6 +6,8 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>0.23.0</VersionPrefix>
     <Authors>Alexandre Mutel</Authors>
+    <!-- Markdig.Wpf still supports net452, a target still supported by by Microsoft until January 10, 2023 -->
+    <!-- see: https://github.com/xoofx/markdig/pull/466 -->
     <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <PackageTags>Markdown CommonMark md html md2html</PackageTags>
     <PackageReleaseNotes>https://github.com/lunet-io/markdig/blob/master/changelog.md</PackageReleaseNotes>

--- a/src/Markdig/Parsers/IndentedCodeBlockParser.cs
+++ b/src/Markdig/Parsers/IndentedCodeBlockParser.cs
@@ -96,7 +96,6 @@ namespace Markdig.Parsers
                 {
                     TriviaBefore = processor.UseTrivia(processor.Start - 1)
                 };
-                cb.CodeBlockLines ??= new List<CodeBlockLine>();
                 cb.CodeBlockLines.Add(codeBlockLine);
                 cb.NewLine = processor.Line.NewLine; // ensure block newline is last newline
             }

--- a/src/Markdig/Parsers/Inlines/AutolinkInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/AutolinkInlineParser.cs
@@ -35,10 +35,9 @@ namespace Markdig.Parsers.Inlines
             int column;
             if (LinkHelper.TryParseAutolink(ref slice, out string? link, out bool isEmail))
             {
-                processor.Inline = new AutolinkInline()
+                processor.Inline = new AutolinkInline(url: link)
                 {
                     IsEmail = isEmail,
-                    Url = link,
                     Span = new SourceSpan(processor.GetSourcePosition(saved.Start, out line, out column), processor.GetSourcePosition(slice.Start - 1)),
                     Line = line,
                     Column = column

--- a/src/Markdig/Parsers/Inlines/AutolinkInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/AutolinkInlineParser.cs
@@ -35,7 +35,7 @@ namespace Markdig.Parsers.Inlines
             int column;
             if (LinkHelper.TryParseAutolink(ref slice, out string? link, out bool isEmail))
             {
-                processor.Inline = new AutolinkInline(url: link)
+                processor.Inline = new AutolinkInline(link)
                 {
                     IsEmail = isEmail,
                     Span = new SourceSpan(processor.GetSourcePosition(saved.Start, out line, out column), processor.GetSourcePosition(slice.Start - 1)),

--- a/src/Markdig/Parsers/Inlines/CodeInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/CodeInlineParser.cs
@@ -107,10 +107,9 @@ namespace Markdig.Parsers.Inlines
                 int delimiterCount = Math.Min(openSticks, closeSticks);
                 var spanStart = processor.GetSourcePosition(startPosition, out int line, out int column);
                 var spanEnd = processor.GetSourcePosition(slice.Start - 1);
-                processor.Inline = new CodeInline()
+                processor.Inline = new CodeInline(content)
                 {
                     Delimiter = match,
-                    Content = content,
                     ContentWithTrivia = new StringSlice(slice.Text, contentStart, contentEnd - 1),
                     Span = new SourceSpan(spanStart, spanEnd),
                     Line = line,

--- a/src/Markdig/Parsers/ListBlockParser.cs
+++ b/src/Markdig/Parsers/ListBlockParser.cs
@@ -262,7 +262,7 @@ namespace Markdig.Parsers
             if ((block ?? state.LastBlock) is ParagraphBlock previousParagraph)
             {
                 if (state.IsBlankLine ||
-                    state.IsOpen(previousParagraph) && listInfo.BulletType == '1' && listInfo.OrderedStart != "1")
+                    state.IsOpen(previousParagraph) && listInfo.BulletType == '1' && listInfo.OrderedStart is not "1")
                 {
                     state.GoToColumn(initColumn);
                     state.TriviaStart = savedTriviaStart; // restore changed TriviaStart state

--- a/src/Markdig/Renderers/Html/CodeBlockRenderer.cs
+++ b/src/Markdig/Renderers/Html/CodeBlockRenderer.cs
@@ -47,7 +47,7 @@ namespace Markdig.Renderers.Html
                 {
                     renderer.Write("<div")
                             .WriteAttributes(obj.TryGetAttributes(),
-                                cls => cls.StartsWith(infoPrefix) ? cls.Substring(infoPrefix.Length) : cls)
+                                cls => cls.StartsWith(infoPrefix, StringComparison.Ordinal) ? cls.Substring(infoPrefix.Length) : cls)
                             .Write(">");
                 }
 

--- a/src/Markdig/Renderers/Html/CodeBlockRenderer.cs
+++ b/src/Markdig/Renderers/Html/CodeBlockRenderer.cs
@@ -48,7 +48,7 @@ namespace Markdig.Renderers.Html
                     renderer.Write("<div")
                             .WriteAttributes(obj.TryGetAttributes(),
                                 cls => cls.StartsWith(infoPrefix, StringComparison.Ordinal) ? cls.Substring(infoPrefix.Length) : cls)
-                            .Write(">");
+                            .Write('>');
                 }
 
                 renderer.WriteLeafRawLines(obj, true, true, true);
@@ -77,7 +77,7 @@ namespace Markdig.Renderers.Html
                         renderer.WriteAttributes(obj);
                     }
 
-                    renderer.Write(">");
+                    renderer.Write('>');
                 }
 
                 renderer.WriteLeafRawLines(obj, true, true);

--- a/src/Markdig/Renderers/Html/HeadingRenderer.cs
+++ b/src/Markdig/Renderers/Html/HeadingRenderer.cs
@@ -31,7 +31,7 @@ namespace Markdig.Renderers.Html
 
             if (renderer.EnableHtmlForBlock)
             {
-                renderer.Write("<").Write(headingText).WriteAttributes(obj).Write(">");
+                renderer.Write("<").Write(headingText).WriteAttributes(obj).Write('>');
             }
 
             renderer.WriteLeafInline(obj);

--- a/src/Markdig/Renderers/Html/Inlines/AutolinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/AutolinkInlineRenderer.cs
@@ -68,7 +68,7 @@ namespace Markdig.Renderers.Html.Inlines
                     renderer.Write($" rel=\"{Rel}\"");
                 }
 
-                renderer.Write(">");
+                renderer.Write('>');
             }
 
             renderer.WriteEscape(obj.Url);

--- a/src/Markdig/Renderers/Html/Inlines/CodeInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/CodeInlineRenderer.cs
@@ -16,7 +16,7 @@ namespace Markdig.Renderers.Html.Inlines
         {
             if (renderer.EnableHtmlForInline)
             {
-                renderer.Write("<code").WriteAttributes(obj).Write(">");
+                renderer.Write("<code").WriteAttributes(obj).Write('>');
             }
             if (renderer.EnableHtmlEscape)
             {

--- a/src/Markdig/Renderers/Html/Inlines/EmphasisInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/EmphasisInlineRenderer.cs
@@ -39,12 +39,12 @@ namespace Markdig.Renderers.Html.Inlines
             if (renderer.EnableHtmlForInline)
             {
                 tag = GetTag(obj);
-                renderer.Write("<").Write(tag).WriteAttributes(obj).Write(">");
+                renderer.Write("<").Write(tag).WriteAttributes(obj).Write('>');
             }
             renderer.WriteChildren(obj);
             if (renderer.EnableHtmlForInline)
             {
-                renderer.Write("</").Write(tag).Write(">");
+                renderer.Write("</").Write(tag).Write('>');
             }
         }
 

--- a/src/Markdig/Renderers/Html/Inlines/LinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Html/Inlines/LinkInlineRenderer.cs
@@ -48,7 +48,7 @@ namespace Markdig.Renderers.Html.Inlines
             {
                 renderer.Write(link.IsImage ? "<img src=\"" : "<a href=\"");
                 renderer.WriteEscapeUrl(link.GetDynamicUrl != null ? link.GetDynamicUrl() ?? link.Url : link.Url);
-                renderer.Write("\"");
+                renderer.Write('"');
                 renderer.WriteAttributes(link);
             }
             if (link.IsImage)
@@ -63,7 +63,7 @@ namespace Markdig.Renderers.Html.Inlines
                 renderer.EnableHtmlForInline = wasEnableHtmlForInline;
                 if (renderer.EnableHtmlForInline)
                 {
-                    renderer.Write("\"");
+                    renderer.Write('"');
                 }
             }
 
@@ -71,7 +71,7 @@ namespace Markdig.Renderers.Html.Inlines
             {
                 renderer.Write(" title=\"");
                 renderer.WriteEscape(link.Title);
-                renderer.Write("\"");
+                renderer.Write('"');
             }
 
             if (link.IsImage)
@@ -89,7 +89,7 @@ namespace Markdig.Renderers.Html.Inlines
                     {
                         renderer.Write($" rel=\"{Rel}\"");
                     }
-                    renderer.Write(">");
+                    renderer.Write('>');
                 }
                 renderer.WriteChildren(link);
                 if (renderer.EnableHtmlForInline)

--- a/src/Markdig/Renderers/Html/ListRenderer.cs
+++ b/src/Markdig/Renderers/Html/ListRenderer.cs
@@ -25,7 +25,7 @@ namespace Markdig.Renderers.Html
                         renderer.Write(" type=\"").Write(listBlock.BulletType).Write("\"");
                     }
 
-                    if (listBlock.OrderedStart != null && (listBlock.OrderedStart != "1"))
+                    if (listBlock.OrderedStart != null && (listBlock.OrderedStart is not "1"))
                     {
                         renderer.Write(" start=\"").Write(listBlock.OrderedStart).Write("\"");
                     }

--- a/src/Markdig/Renderers/Html/ListRenderer.cs
+++ b/src/Markdig/Renderers/Html/ListRenderer.cs
@@ -22,21 +22,21 @@ namespace Markdig.Renderers.Html
                     renderer.Write("<ol");
                     if (listBlock.BulletType != '1')
                     {
-                        renderer.Write(" type=\"").Write(listBlock.BulletType).Write("\"");
+                        renderer.Write(" type=\"").Write(listBlock.BulletType).Write('"');
                     }
 
                     if (listBlock.OrderedStart != null && (listBlock.OrderedStart is not "1"))
                     {
-                        renderer.Write(" start=\"").Write(listBlock.OrderedStart).Write("\"");
+                        renderer.Write(" start=\"").Write(listBlock.OrderedStart).Write('"');
                     }
                     renderer.WriteAttributes(listBlock);
-                    renderer.WriteLine(">");
+                    renderer.WriteLine('>');
                 }
                 else
                 {
                     renderer.Write("<ul");
                     renderer.WriteAttributes(listBlock);
-                    renderer.WriteLine(">");
+                    renderer.WriteLine('>');
                 }
             }
 
@@ -49,7 +49,7 @@ namespace Markdig.Renderers.Html
                 renderer.EnsureLine();
                 if (renderer.EnableHtmlForBlock)
                 {
-                    renderer.Write("<li").WriteAttributes(listItem).Write(">");
+                    renderer.Write("<li").WriteAttributes(listItem).Write('>');
                 }
 
                 renderer.WriteChildren(listItem);

--- a/src/Markdig/Renderers/HtmlRenderer.cs
+++ b/src/Markdig/Renderers/HtmlRenderer.cs
@@ -360,7 +360,7 @@ namespace Markdig.Renderers
 
             if (attributes.Id != null)
             {
-                Write(" id=\"").WriteEscape(attributes.Id).Write("\"");
+                Write(" id=\"").WriteEscape(attributes.Id).Write('"');
             }
 
             if (attributes.Classes is { Count: > 0 })
@@ -371,21 +371,21 @@ namespace Markdig.Renderers
                     var cssClass = attributes.Classes[i];
                     if (i > 0)
                     {
-                        Write(" ");
+                        Write(' ');
                     }
                     WriteEscape(classFilter != null ? classFilter(cssClass) : cssClass);
                 }
-                Write("\"");
+                Write('"');
             }
 
             if (attributes.Properties is { Count: > 0 })
             {
                 foreach (var property in attributes.Properties)
                 {
-                    Write(" ").Write(property.Key);
-                    Write("=").Write("\"");
+                    Write(' ').Write(property.Key);
+                    Write("=\"");
                     WriteEscape(property.Value ?? "");
-                    Write("\"");
+                    Write('"');
                 }
             }
 

--- a/src/Markdig/Renderers/Normalize/CodeBlockRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/CodeBlockRenderer.cs
@@ -2,8 +2,8 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-using Markdig.Syntax;
 using System;
+using Markdig.Syntax;
 
 namespace Markdig.Renderers.Normalize
 {
@@ -28,14 +28,14 @@ namespace Markdig.Renderers.Normalize
                 }
                 if (!string.IsNullOrEmpty(fencedCodeBlock.Arguments))
                 {
-                    renderer.Write(" ").Write(fencedCodeBlock.Arguments);
+                    renderer.Write(' ').Write(fencedCodeBlock.Arguments);
                 }
 
                 /* TODO do we need this causes a empty space and would render html attributes to markdown.
                 var attributes = obj.TryGetAttributes();
                 if (attributes != null)
                 {
-                    renderer.Write(" ");
+                    renderer.Write(' ');
                     renderer.Write(attributes);
                 }
                 */

--- a/src/Markdig/Renderers/Normalize/Inlines/LinkInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/LinkInlineRenderer.cs
@@ -48,7 +48,7 @@ namespace Markdig.Renderers.Normalize.Inlines
                     {
                         renderer.Write(" \"");
                         renderer.Write(link.Title.Replace(@"""", @"\"""));
-                        renderer.Write("\"");
+                        renderer.Write('"');
                     }
 
                     renderer.Write(')');

--- a/src/Markdig/Renderers/Normalize/NormalizeRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/NormalizeRenderer.cs
@@ -87,7 +87,7 @@ namespace Markdig.Renderers.Normalize
 
         //    if (attributes.Id != null)
         //    {
-        //        Write(" id=\"").WriteEscape(attributes.Id).Write("\"");
+        //        Write(" id=\"").WriteEscape(attributes.Id).Write('"');
         //    }
 
         //    if (attributes.Classes != null && attributes.Classes.Count > 0)
@@ -102,19 +102,19 @@ namespace Markdig.Renderers.Normalize
         //            }
         //            WriteEscape(cssClass);
         //        }
-        //        Write("\"");
+        //        Write('"');
         //    }
 
         //    if (attributes.Properties != null && attributes.Properties.Count > 0)
         //    {
         //        foreach (var property in attributes.Properties)
         //        {
-        //            Write(" ").Write(property.Key);
+        //            Write(' ').Write(property.Key);
         //            if (property.Value != null)
         //            {
-        //                Write("=").Write("\"");
+        //                Write('=').Write('"');
         //                WriteEscape(property.Value);
-        //                Write("\"");
+        //                Write('"');
         //            }
         //        }
         //    }

--- a/src/Markdig/Renderers/Roundtrip/CodeBlockRenderer.cs
+++ b/src/Markdig/Renderers/Roundtrip/CodeBlockRenderer.cs
@@ -67,10 +67,10 @@ namespace Markdig.Renderers.Roundtrip
             }
             else
             {
-                var indents = new List<string>();
-                foreach (var cbl in obj.CodeBlockLines)
+                var indents = new string[obj.CodeBlockLines.Count];
+                for (int i = 0; i < obj.CodeBlockLines.Count; i++)
                 {
-                    indents.Add(cbl.TriviaBefore.ToString());
+                    indents[i] = obj.CodeBlockLines[i].TriviaBefore.ToString();
                 }
                 renderer.PushIndent(indents);
                 WriteLeafRawLines(renderer, obj);

--- a/src/Markdig/Renderers/Roundtrip/ListRenderer.cs
+++ b/src/Markdig/Renderers/Roundtrip/ListRenderer.cs
@@ -2,7 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-using System.Collections.Generic;
 using Markdig.Helpers;
 using Markdig.Syntax;
 
@@ -28,7 +27,7 @@ namespace Markdig.Renderers.Roundtrip
                     var bws = listItem.TriviaBefore.ToString();
                     var bullet = listItem.SourceBullet.ToString();
                     var delimiter = listBlock.OrderedDelimiter;
-                    renderer.PushIndent(new List<string> { $@"{bws}{bullet}{delimiter}" });
+                    renderer.PushIndent(new string[] { $"{bws}{bullet}{delimiter}" });
                     renderer.WriteChildren(listItem);
                     renderer.RenderLinesAfter(listItem);
                 }
@@ -45,7 +44,7 @@ namespace Markdig.Renderers.Roundtrip
                     char bullet = listBlock.BulletType;
                     StringSlice aws = listItem.TriviaAfter;
 
-                    renderer.PushIndent(new List<string> { $@"{bws}{bullet}{aws}" });
+                    renderer.PushIndent(new string[] { $"{bws}{bullet}{aws}" });
                     if (listItem.Count == 0)
                     {
                         renderer.Write(""); // trigger writing of indent

--- a/src/Markdig/Renderers/Roundtrip/QuoteBlockRenderer.cs
+++ b/src/Markdig/Renderers/Roundtrip/QuoteBlockRenderer.cs
@@ -4,7 +4,6 @@
 
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
-using System.Collections.Generic;
 
 namespace Markdig.Renderers.Roundtrip
 {

--- a/src/Markdig/Renderers/Roundtrip/QuoteBlockRenderer.cs
+++ b/src/Markdig/Renderers/Roundtrip/QuoteBlockRenderer.cs
@@ -18,14 +18,15 @@ namespace Markdig.Renderers.Roundtrip
             renderer.RenderLinesBefore(quoteBlock);
             renderer.Write(quoteBlock.TriviaBefore);
 
-            var indents = new List<string>();
-            foreach (var quoteLine in quoteBlock.QuoteLines)
+            var indents = new string[quoteBlock.QuoteLines.Count];
+            for (int i = 0; i < quoteBlock.QuoteLines.Count; i++)
             {
+                var quoteLine = quoteBlock.QuoteLines[i];
                 var wsb = quoteLine.TriviaBefore.ToString();
                 var quoteChar = quoteLine.QuoteChar ? ">" : "";
                 var spaceAfterQuoteChar = quoteLine.HasSpaceAfterQuoteChar ? " " : "";
                 var wsa = quoteLine.TriviaAfter.ToString();
-                indents.Add(wsb + quoteChar + spaceAfterQuoteChar + wsa);
+                indents[i] = (wsb + quoteChar + spaceAfterQuoteChar + wsa);
             }
             bool noChildren = false;
             if (quoteBlock.Count == 0)

--- a/src/Markdig/Renderers/TextRendererBase.cs
+++ b/src/Markdig/Renderers/TextRendererBase.cs
@@ -327,6 +327,20 @@ namespace Markdig.Renderers
         }
 
         /// <summary>
+        /// Writes a content followed by a newline.
+        /// </summary>
+        /// <param name="content">The content.</param>
+        /// <returns>This instance</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public T WriteLine(char content)
+        {
+            WriteIndent();
+            previousWasLine = true;
+            Writer.WriteLine(content);
+            return (T)this;
+        }
+
+        /// <summary>
         /// Writes the inlines of a leaf inline.
         /// </summary>
         /// <param name="leafBlock">The leaf block.</param>

--- a/src/Markdig/Renderers/TextRendererBase.cs
+++ b/src/Markdig/Renderers/TextRendererBase.cs
@@ -71,19 +71,20 @@ namespace Markdig.Renderers
     /// <seealso cref="RendererBase" />
     public abstract class TextRendererBase<T> : TextRendererBase where T : TextRendererBase<T>
     {
-        private class Indent
+        private sealed class Indent
         {
             private readonly string? _constant;
-            private readonly Queue<string>? _lineSpecific;
+            private readonly string[]? _lineSpecific;
+            private int position;
 
             internal Indent(string constant)
             {
                 _constant = constant;
             }
 
-            internal Indent(IEnumerable<string> lineSpecific)
+            internal Indent(string[] lineSpecific)
             {
-                _lineSpecific = new Queue<string>(lineSpecific);
+                _lineSpecific = lineSpecific;
             }
 
             internal string Next()
@@ -94,9 +95,9 @@ namespace Markdig.Renderers
                 }
 
                 //if (_lineSpecific.Count == 0) throw new Exception("Indents empty");
-                if (_lineSpecific!.Count == 0) return string.Empty;
-                var next = _lineSpecific.Dequeue();
-                return next;
+                if (position == _lineSpecific!.Length) return string.Empty;
+
+                return _lineSpecific![position++];
             }
         }
 
@@ -160,7 +161,7 @@ namespace Markdig.Renderers
             indents.Add(new Indent(indent));
         }
 
-        public void PushIndent(IEnumerable<string> lineSpecific)
+        public void PushIndent(string[] lineSpecific)
         {
             if (indents is null) ThrowHelper.ArgumentNullException(nameof(indents));
             indents.Add(new Indent(lineSpecific));

--- a/src/Markdig/Syntax/CodeBlock.cs
+++ b/src/Markdig/Syntax/CodeBlock.cs
@@ -21,7 +21,7 @@ namespace Markdig.Syntax
             public StringSlice TriviaBefore { get; set; }
         }
 
-        public List<CodeBlockLine> CodeBlockLines { get; set; } = new List<CodeBlockLine>();
+        public List<CodeBlockLine> CodeBlockLines { get; } = new ();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CodeBlock"/> class.

--- a/src/Markdig/Syntax/Inlines/AutolinkInline.cs
+++ b/src/Markdig/Syntax/Inlines/AutolinkInline.cs
@@ -2,8 +2,6 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 
 namespace Markdig.Syntax.Inlines
@@ -13,8 +11,13 @@ namespace Markdig.Syntax.Inlines
     /// </summary>
     /// <seealso cref="LeafInline" />
     [DebuggerDisplay("<{Url}>")]
-    public class AutolinkInline : LeafInline
+    public sealed class AutolinkInline : LeafInline
     {
+        public AutolinkInline(string url)
+        {
+            Url = url;
+        }
+
         /// <summary>
         /// Gets or sets a value indicating whether this instance is an email link.
         /// </summary>

--- a/src/Markdig/Syntax/Inlines/CodeInline.cs
+++ b/src/Markdig/Syntax/Inlines/CodeInline.cs
@@ -14,6 +14,11 @@ namespace Markdig.Syntax.Inlines
     [DebuggerDisplay("`{Content}`")]
     public class CodeInline : LeafInline
     {
+        public CodeInline(string content)
+        {
+            Content = content;
+        }
+
         /// <summary>
         /// Gets or sets the delimiter character used by this code inline.
         /// </summary>
@@ -27,7 +32,7 @@ namespace Markdig.Syntax.Inlines
         /// <summary>
         /// Gets or sets the content of the span.
         /// </summary>
-        public string? Content { get; set; }
+        public string Content { get; set; }
 
         /// <summary>
         /// Gets or sets the content with trivia and whitespace.

--- a/src/Markdig/Syntax/QuoteBlock.cs
+++ b/src/Markdig/Syntax/QuoteBlock.cs
@@ -27,7 +27,7 @@ namespace Markdig.Syntax
         /// Trivia: only parsed when <see cref="MarkdownParser.TrackTrivia"/> is enabled, otherwise
         /// <see cref="StringSlice.IsEmpty"/>.
         /// </summary>
-        public List<QuoteBlockLine> QuoteLines { get; set; } = new List<QuoteBlockLine>();
+        public List<QuoteBlockLine> QuoteLines { get; } = new ();
 
         /// <summary>
         /// Gets or sets the quote character (usually `&gt;`)


### PR DESCRIPTION
This PR:

- Compares strings using StringComparison.Ordinal or pattern matching to avoid culture differences
- Writes  chars, where possible, to avoid passing references
- Eliminates a few allocations
- Enables nullable in a few more places
- Ensures CodeInline.Content is initialized by adding a constructor
- Seals renderer classes to ensure they are not subclassed