### PR TITLE
JiraLinkInlineParser.cs - Make digits in JiraKey's posible

### DIFF
--- a/src/Markdig.Tests/Specs/JiraLinks.generated.cs
+++ b/src/Markdig.Tests/Specs/JiraLinks.generated.cs
@@ -23,7 +23,7 @@ namespace Markdig.Tests.Specs.JiraLinks
         // 
         // The rules for detecting a link are:
         // 
-        // - The project key must be composed of one or more capitalized ASCII letter `[A-Z]+`
+        // - The project key must be composed of one or more capitalized ASCII letters or digits `[A-Z,0-9]+`
         // - A single hyphen `-` must separate the project key and issue number.
         // - The issue number is composed of 1 or more digits `[0, 9]+`
         // - The reference must be preceded by either `(` or whitespace or EOF.
@@ -53,13 +53,13 @@ namespace Markdig.Tests.Specs.JiraLinks
             // Section: Jira Links
             //
             // The following Markdown:
-            //     This is a KIRA-1 issue
+            //     This is a ABC4-123 issue
             //
             // Should be rendered as:
-            //     <p>This is a <a href="http://your.company.abc/browse/KIRA-1" target="blank">KIRA-1</a> issue</p>
+            //     <p>This is a <a href="http://your.company.abc/browse/ABC4-123" target="blank">ABC4-123</a> issue</p>
 
             Console.WriteLine("Example 2\nSection Jira Links\n");
-            TestParser.TestSpec("This is a KIRA-1 issue", "<p>This is a <a href=\"http://your.company.abc/browse/KIRA-1\" target=\"blank\">KIRA-1</a> issue</p>", "jiralinks");
+            TestParser.TestSpec("This is a ABC4-123 issue", "<p>This is a <a href=\"http://your.company.abc/browse/ABC4-123\" target=\"blank\">ABC4-123</a> issue</p>", "jiralinks");
         }
 
         [Test]
@@ -69,16 +69,15 @@ namespace Markdig.Tests.Specs.JiraLinks
             // Section: Jira Links
             //
             // The following Markdown:
-            //     This is a Z-1 issue
+            //     This is a ABC45-123 issue
             //
             // Should be rendered as:
-            //     <p>This is a <a href="http://your.company.abc/browse/Z-1" target="blank">Z-1</a> issue</p>
+            //     <p>This is a <a href="http://your.company.abc/browse/ABC45-123" target="blank">ABC45-123</a> issue</p>
 
             Console.WriteLine("Example 3\nSection Jira Links\n");
-            TestParser.TestSpec("This is a Z-1 issue", "<p>This is a <a href=\"http://your.company.abc/browse/Z-1\" target=\"blank\">Z-1</a> issue</p>", "jiralinks");
+            TestParser.TestSpec("This is a ABC45-123 issue", "<p>This is a <a href=\"http://your.company.abc/browse/ABC45-123\" target=\"blank\">ABC45-123</a> issue</p>", "jiralinks");
         }
 
-        // These are also valid links with `(` and `)`:
         [Test]
         public void JiraLinks_Example004()
         {
@@ -86,13 +85,13 @@ namespace Markdig.Tests.Specs.JiraLinks
             // Section: Jira Links
             //
             // The following Markdown:
-            //     This is a (ABCD-123) issue
+            //     This is a KIRA-1 issue
             //
             // Should be rendered as:
-            //     <p>This is a (<a href="http://your.company.abc/browse/ABCD-123" target="blank">ABCD-123</a>) issue</p>
+            //     <p>This is a <a href="http://your.company.abc/browse/KIRA-1" target="blank">KIRA-1</a> issue</p>
 
             Console.WriteLine("Example 4\nSection Jira Links\n");
-            TestParser.TestSpec("This is a (ABCD-123) issue", "<p>This is a (<a href=\"http://your.company.abc/browse/ABCD-123\" target=\"blank\">ABCD-123</a>) issue</p>", "jiralinks");
+            TestParser.TestSpec("This is a KIRA-1 issue", "<p>This is a <a href=\"http://your.company.abc/browse/KIRA-1\" target=\"blank\">KIRA-1</a> issue</p>", "jiralinks");
         }
 
         [Test]
@@ -102,15 +101,16 @@ namespace Markdig.Tests.Specs.JiraLinks
             // Section: Jira Links
             //
             // The following Markdown:
-            //     This is a (KIRA-1) issue
+            //     This is a Z-1 issue
             //
             // Should be rendered as:
-            //     <p>This is a (<a href="http://your.company.abc/browse/KIRA-1" target="blank">KIRA-1</a>) issue</p>
+            //     <p>This is a <a href="http://your.company.abc/browse/Z-1" target="blank">Z-1</a> issue</p>
 
             Console.WriteLine("Example 5\nSection Jira Links\n");
-            TestParser.TestSpec("This is a (KIRA-1) issue", "<p>This is a (<a href=\"http://your.company.abc/browse/KIRA-1\" target=\"blank\">KIRA-1</a>) issue</p>", "jiralinks");
+            TestParser.TestSpec("This is a Z-1 issue", "<p>This is a <a href=\"http://your.company.abc/browse/Z-1\" target=\"blank\">Z-1</a> issue</p>", "jiralinks");
         }
 
+        // These are also valid links with `(` and `)`:
         [Test]
         public void JiraLinks_Example006()
         {
@@ -118,16 +118,15 @@ namespace Markdig.Tests.Specs.JiraLinks
             // Section: Jira Links
             //
             // The following Markdown:
-            //     This is a (Z-1) issue
+            //     This is a (ABCD-123) issue
             //
             // Should be rendered as:
-            //     <p>This is a (<a href="http://your.company.abc/browse/Z-1" target="blank">Z-1</a>) issue</p>
+            //     <p>This is a (<a href="http://your.company.abc/browse/ABCD-123" target="blank">ABCD-123</a>) issue</p>
 
             Console.WriteLine("Example 6\nSection Jira Links\n");
-            TestParser.TestSpec("This is a (Z-1) issue", "<p>This is a (<a href=\"http://your.company.abc/browse/Z-1\" target=\"blank\">Z-1</a>) issue</p>", "jiralinks");
+            TestParser.TestSpec("This is a (ABCD-123) issue", "<p>This is a (<a href=\"http://your.company.abc/browse/ABCD-123\" target=\"blank\">ABCD-123</a>) issue</p>", "jiralinks");
         }
 
-        // These are not valid links:
         [Test]
         public void JiraLinks_Example007()
         {
@@ -135,13 +134,13 @@ namespace Markdig.Tests.Specs.JiraLinks
             // Section: Jira Links
             //
             // The following Markdown:
-            //     This is not aJIRA-123 issue
+            //     This is a (ABC4-123) issue
             //
             // Should be rendered as:
-            //     <p>This is not aJIRA-123 issue</p>
+            //     <p>This is a (<a href="http://your.company.abc/browse/ABC4-123" target="blank">ABC4-123</a>) issue</p>
 
             Console.WriteLine("Example 7\nSection Jira Links\n");
-            TestParser.TestSpec("This is not aJIRA-123 issue", "<p>This is not aJIRA-123 issue</p>", "jiralinks");
+            TestParser.TestSpec("This is a (ABC4-123) issue", "<p>This is a (<a href=\"http://your.company.abc/browse/ABC4-123\" target=\"blank\">ABC4-123</a>) issue</p>", "jiralinks");
         }
 
         [Test]
@@ -151,13 +150,13 @@ namespace Markdig.Tests.Specs.JiraLinks
             // Section: Jira Links
             //
             // The following Markdown:
-            //     This is not JIRA-123a issue
+            //     This is a (KIRA-1) issue
             //
             // Should be rendered as:
-            //     <p>This is not JIRA-123a issue</p>
+            //     <p>This is a (<a href="http://your.company.abc/browse/KIRA-1" target="blank">KIRA-1</a>) issue</p>
 
             Console.WriteLine("Example 8\nSection Jira Links\n");
-            TestParser.TestSpec("This is not JIRA-123a issue", "<p>This is not JIRA-123a issue</p>", "jiralinks");
+            TestParser.TestSpec("This is a (KIRA-1) issue", "<p>This is a (<a href=\"http://your.company.abc/browse/KIRA-1\" target=\"blank\">KIRA-1</a>) issue</p>", "jiralinks");
         }
 
         [Test]
@@ -167,13 +166,78 @@ namespace Markdig.Tests.Specs.JiraLinks
             // Section: Jira Links
             //
             // The following Markdown:
+            //     This is a (Z-1) issue
+            //
+            // Should be rendered as:
+            //     <p>This is a (<a href="http://your.company.abc/browse/Z-1" target="blank">Z-1</a>) issue</p>
+
+            Console.WriteLine("Example 9\nSection Jira Links\n");
+            TestParser.TestSpec("This is a (Z-1) issue", "<p>This is a (<a href=\"http://your.company.abc/browse/Z-1\" target=\"blank\">Z-1</a>) issue</p>", "jiralinks");
+        }
+
+        // These are not valid links:
+        [Test]
+        public void JiraLinks_Example010()
+        {
+            // Example 10
+            // Section: Jira Links
+            //
+            // The following Markdown:
+            //     This is not aJIRA-123 issue
+            //
+            // Should be rendered as:
+            //     <p>This is not aJIRA-123 issue</p>
+
+            Console.WriteLine("Example 10\nSection Jira Links\n");
+            TestParser.TestSpec("This is not aJIRA-123 issue", "<p>This is not aJIRA-123 issue</p>", "jiralinks");
+        }
+
+        [Test]
+        public void JiraLinks_Example011()
+        {
+            // Example 11
+            // Section: Jira Links
+            //
+            // The following Markdown:
+            //     This is not JIRA-123a issue
+            //
+            // Should be rendered as:
+            //     <p>This is not JIRA-123a issue</p>
+
+            Console.WriteLine("Example 11\nSection Jira Links\n");
+            TestParser.TestSpec("This is not JIRA-123a issue", "<p>This is not JIRA-123a issue</p>", "jiralinks");
+        }
+
+        [Test]
+        public void JiraLinks_Example012()
+        {
+            // Example 12
+            // Section: Jira Links
+            //
+            // The following Markdown:
             //     This is not JIRA- issue
             //
             // Should be rendered as:
             //     <p>This is not JIRA- issue</p>
 
-            Console.WriteLine("Example 9\nSection Jira Links\n");
+            Console.WriteLine("Example 12\nSection Jira Links\n");
             TestParser.TestSpec("This is not JIRA- issue", "<p>This is not JIRA- issue</p>", "jiralinks");
+        }
+
+        [Test]
+        public void JiraLinks_Example013()
+        {
+            // Example 13
+            // Section: Jira Links
+            //
+            // The following Markdown:
+            //     This is not JIR4- issue
+            //
+            // Should be rendered as:
+            //     <p>This is not JIR4- issue</p>
+
+            Console.WriteLine("Example 13\nSection Jira Links\n");
+            TestParser.TestSpec("This is not JIR4- issue", "<p>This is not JIR4- issue</p>", "jiralinks");
         }
     }
 }

--- a/src/Markdig.Tests/Specs/JiraLinks.generated.cs
+++ b/src/Markdig.Tests/Specs/JiraLinks.generated.cs
@@ -199,13 +199,13 @@ namespace Markdig.Tests.Specs.JiraLinks
             // Section: Jira Links
             //
             // The following Markdown:
-            //     This is not JIRA-123a issue
+            //     This is not 4JIRA-123 issue
             //
             // Should be rendered as:
-            //     <p>This is not JIRA-123a issue</p>
+            //     <p>This is not 4JIRA-123 issue</p>
 
             Console.WriteLine("Example 11\nSection Jira Links\n");
-            TestParser.TestSpec("This is not JIRA-123a issue", "<p>This is not JIRA-123a issue</p>", "jiralinks");
+            TestParser.TestSpec("This is not 4JIRA-123 issue", "<p>This is not 4JIRA-123 issue</p>", "jiralinks");
         }
 
         [Test]
@@ -215,13 +215,13 @@ namespace Markdig.Tests.Specs.JiraLinks
             // Section: Jira Links
             //
             // The following Markdown:
-            //     This is not JIRA- issue
+            //     This is not JIRA-123a issue
             //
             // Should be rendered as:
-            //     <p>This is not JIRA- issue</p>
+            //     <p>This is not JIRA-123a issue</p>
 
             Console.WriteLine("Example 12\nSection Jira Links\n");
-            TestParser.TestSpec("This is not JIRA- issue", "<p>This is not JIRA- issue</p>", "jiralinks");
+            TestParser.TestSpec("This is not JIRA-123a issue", "<p>This is not JIRA-123a issue</p>", "jiralinks");
         }
 
         [Test]
@@ -231,12 +231,28 @@ namespace Markdig.Tests.Specs.JiraLinks
             // Section: Jira Links
             //
             // The following Markdown:
+            //     This is not JIRA- issue
+            //
+            // Should be rendered as:
+            //     <p>This is not JIRA- issue</p>
+
+            Console.WriteLine("Example 13\nSection Jira Links\n");
+            TestParser.TestSpec("This is not JIRA- issue", "<p>This is not JIRA- issue</p>", "jiralinks");
+        }
+
+        [Test]
+        public void JiraLinks_Example014()
+        {
+            // Example 14
+            // Section: Jira Links
+            //
+            // The following Markdown:
             //     This is not JIR4- issue
             //
             // Should be rendered as:
             //     <p>This is not JIR4- issue</p>
 
-            Console.WriteLine("Example 13\nSection Jira Links\n");
+            Console.WriteLine("Example 14\nSection Jira Links\n");
             TestParser.TestSpec("This is not JIR4- issue", "<p>This is not JIR4- issue</p>", "jiralinks");
         }
     }

--- a/src/Markdig.Tests/Specs/JiraLinks.md
+++ b/src/Markdig.Tests/Specs/JiraLinks.md
@@ -83,6 +83,12 @@ This is not aJIRA-123 issue
 ````````````````````````````````
 
 ```````````````````````````````` example
+This is not 4JIRA-123 issue
+.
+<p>This is not 4JIRA-123 issue</p>
+````````````````````````````````
+
+```````````````````````````````` example
 This is not JIRA-123a issue
 .
 <p>This is not JIRA-123a issue</p>

--- a/src/Markdig.Tests/Specs/JiraLinks.md
+++ b/src/Markdig.Tests/Specs/JiraLinks.md
@@ -10,7 +10,7 @@ var pipeline = new MarkdownPipelineBuilder()
 
 The rules for detecting a link are:
 
-- The project key must be composed of one or more capitalized ASCII letter `[A-Z]+`
+- The project key must be composed of one or more capitalized ASCII letters or digits `[A-Z,0-9]+`
 - A single hyphen `-` must separate the project key and issue number.
 - The issue number is composed of 1 or more digits `[0, 9]+`
 - The reference must be preceded by either `(` or whitespace or EOF.
@@ -22,6 +22,18 @@ The following are valid examples:
 This is a ABCD-123 issue
 .
 <p>This is a <a href="http://your.company.abc/browse/ABCD-123" target="blank">ABCD-123</a> issue</p>
+````````````````````````````````
+
+```````````````````````````````` example
+This is a ABC4-123 issue
+.
+<p>This is a <a href="http://your.company.abc/browse/ABC4-123" target="blank">ABC4-123</a> issue</p>
+````````````````````````````````
+
+```````````````````````````````` example
+This is a ABC45-123 issue
+.
+<p>This is a <a href="http://your.company.abc/browse/ABC45-123" target="blank">ABC45-123</a> issue</p>
 ````````````````````````````````
 
 ```````````````````````````````` example
@@ -42,6 +54,12 @@ These are also valid links with `(` and `)`:
 This is a (ABCD-123) issue
 .
 <p>This is a (<a href="http://your.company.abc/browse/ABCD-123" target="blank">ABCD-123</a>) issue</p>
+````````````````````````````````
+
+```````````````````````````````` example
+This is a (ABC4-123) issue
+.
+<p>This is a (<a href="http://your.company.abc/browse/ABC4-123" target="blank">ABC4-123</a>) issue</p>
 ````````````````````````````````
 
 ```````````````````````````````` example
@@ -74,4 +92,10 @@ This is not JIRA-123a issue
 This is not JIRA- issue
 .
 <p>This is not JIRA- issue</p>
+````````````````````````````````
+
+```````````````````````````````` example
+This is not JIR4- issue
+.
+<p>This is not JIR4- issue</p>
 ````````````````````````````````

--- a/src/Markdig/Extensions/JiraLinks/JiraLinkInlineParser.cs
+++ b/src/Markdig/Extensions/JiraLinks/JiraLinkInlineParser.cs
@@ -40,7 +40,13 @@ namespace Markdig.Extensions.JiraLinks
             var startKey = slice.Start;
             var endKey = slice.Start;
 
-            //read as many uppercase characters as required - project key
+            // the first character of the key can not be a digit.
+            if (current.IsDigit())
+            {
+                return false;
+            }
+
+            // read as many uppercase characters or digits as required - project key
             while (current.IsAlphaUpper() || current.IsDigit())
             {
                 endKey = slice.Start;

--- a/src/Markdig/Extensions/JiraLinks/JiraLinkInlineParser.cs
+++ b/src/Markdig/Extensions/JiraLinks/JiraLinkInlineParser.cs
@@ -41,7 +41,7 @@ namespace Markdig.Extensions.JiraLinks
             var endKey = slice.Start;
 
             //read as many uppercase characters as required - project key
-            while (current.IsAlphaUpper())
+            while (current.IsAlphaUpper() || current.IsDigit())
             {
                 endKey = slice.Start;
                 current = slice.NextChar();


### PR DESCRIPTION
A digit can also be part of the project key for example T3ST is a valid project key and T3ST-123 is thus a valid Jira issue number but it will not be recognized by this tool. 
I propose to add an OR IsDigit() check like: 'while (current.IsAlphaUpper() || current.IsDigit())'
Thanks for considering to update.