### PR TITLE
Fix typo in EmphasisExtraOptions descriptions

### DIFF
--- a/src/Markdig/Extensions/EmphasisExtras/EmphasisExtraOptions.cs
+++ b/src/Markdig/Extensions/EmphasisExtras/EmphasisExtraOptions.cs
@@ -33,12 +33,12 @@ namespace Markdig.Extensions.EmphasisExtras
         Superscript = 4,
 
         /// <summary>
-        /// A text that can be rendered as a inserted using the character ++
+        /// A text that can be rendered as a inserted using the double character ++
         /// </summary>
         Inserted = 8,
 
         /// <summary>
-        /// A text that can be rendered as a inserted using the character ==
+        /// A text that can be rendered as a marked using the double character ==
         /// </summary>
         Marked = 16,
     }

--- a/src/Markdig/Extensions/EmphasisExtras/EmphasisExtraOptions.cs
+++ b/src/Markdig/Extensions/EmphasisExtras/EmphasisExtraOptions.cs
@@ -38,7 +38,7 @@ namespace Markdig.Extensions.EmphasisExtras
         Inserted = 8,
 
         /// <summary>
-        /// A text that can be rendered as a marked using the double character ==
+        /// A text that can be rendered as marked using the double character ==
         /// </summary>
         Marked = 16,
     }

--- a/src/Markdig/Extensions/EmphasisExtras/EmphasisExtraOptions.cs
+++ b/src/Markdig/Extensions/EmphasisExtras/EmphasisExtraOptions.cs
@@ -33,7 +33,7 @@ namespace Markdig.Extensions.EmphasisExtras
         Superscript = 4,
 
         /// <summary>
-        /// A text that can be rendered as a inserted using the double character ++
+        /// A text that can be rendered as inserted using the double character ++
         /// </summary>
         Inserted = 8,
 


### PR DESCRIPTION
Correct some small typos in the descriptions of some of the members of EmphasisExtraOptions

I did not find a contributing doc in the repo so I took a look at the recently completed PR and attempted to follow what they were doing.

If you are not accepting contributions, thats ok too.  It won't hurt my feelings 😀.  