### PR TITLE
ADD: Context to Renderer

### DIFF
--- a/src/Markdig/Markdown.cs
+++ b/src/Markdig/Markdown.cs
@@ -72,7 +72,7 @@ namespace Markdig
 
             var document = MarkdownParser.Parse(markdown, pipeline, context);
 
-            var renderer = new NormalizeRenderer(writer, options);
+            var renderer = new NormalizeRenderer(writer, options, context);
             pipeline.Setup(renderer);
 
             renderer.Render(document);
@@ -97,7 +97,7 @@ namespace Markdig
 
             var document = MarkdownParser.Parse(markdown, pipeline, context);
 
-            return ToHtml(document, pipeline);
+            return ToHtml(document, pipeline, context);
         }
 
         /// <summary>
@@ -107,13 +107,13 @@ namespace Markdig
         /// <param name="pipeline">The pipeline used for the conversion.</param>
         /// <returns>The result of the conversion</returns>
         /// <exception cref="ArgumentNullException">if markdown document variable is null</exception>
-        public static string ToHtml(this MarkdownDocument document, MarkdownPipeline? pipeline = null)
+        public static string ToHtml(this MarkdownDocument document, MarkdownPipeline? pipeline = null, MarkdownParserContext? context = null)
         {
             if (document is null) ThrowHelper.ArgumentNullException(nameof(document));
 
             pipeline ??= DefaultPipeline;
 
-            using var rentedRenderer = pipeline.RentHtmlRenderer();
+            using var rentedRenderer = pipeline.RentHtmlRenderer(null, context);
             HtmlRenderer renderer = rentedRenderer.Instance;
 
             renderer.Render(document);
@@ -140,7 +140,7 @@ namespace Markdig
 
             var document = MarkdownParser.Parse(markdown, pipeline, context);
 
-            using var rentedRenderer = pipeline.RentHtmlRenderer(writer);
+            using var rentedRenderer = pipeline.RentHtmlRenderer(writer, context);
             HtmlRenderer renderer = rentedRenderer.Instance;
 
             renderer.Render(document);

--- a/src/Markdig/MarkdownPipeline.cs
+++ b/src/Markdig/MarkdownPipeline.cs
@@ -76,7 +76,7 @@ namespace Markdig
         private HtmlRendererCache? _rendererCache;
         private HtmlRendererCache? _rendererCacheForCustomWriter;
 
-        internal RentedHtmlRenderer RentHtmlRenderer(TextWriter? writer = null)
+        internal RentedHtmlRenderer RentHtmlRenderer(TextWriter? writer = null, MarkdownParserContext? context = null)
         {
             HtmlRendererCache cache = writer is null
                 ? _rendererCache ??= new HtmlRendererCache(this, customWriter: false)
@@ -100,17 +100,19 @@ namespace Markdig
 
             private readonly MarkdownPipeline _pipeline;
             private readonly bool _customWriter;
+            private readonly MarkdownParserContext? _context;
 
-            public HtmlRendererCache(MarkdownPipeline pipeline, bool customWriter = false)
+            public HtmlRendererCache(MarkdownPipeline pipeline, bool customWriter = false, MarkdownParserContext? context = null)
             {
                 _pipeline = pipeline;
                 _customWriter = customWriter;
+                _context = context;
             }
 
             protected override HtmlRenderer NewInstance()
             {
                 var writer = _customWriter ? _dummyWriter : new StringWriter(new StringBuilder(InitialCapacity));
-                var renderer = new HtmlRenderer(writer);
+                var renderer = new HtmlRenderer(writer, _context);
                 _pipeline.Setup(renderer);
                 return renderer;
             }

--- a/src/Markdig/Renderers/HtmlRenderer.cs
+++ b/src/Markdig/Renderers/HtmlRenderer.cs
@@ -24,7 +24,7 @@ namespace Markdig.Renderers
         /// Initializes a new instance of the <see cref="HtmlRenderer"/> class.
         /// </summary>
         /// <param name="writer">The writer.</param>
-        public HtmlRenderer(TextWriter writer) : base(writer)
+        public HtmlRenderer(TextWriter writer, MarkdownParserContext? context = null) : base(writer, context)
         {
             // Default block renderers
             ObjectRenderers.Add(new CodeBlockRenderer());

--- a/src/Markdig/Renderers/Normalize/NormalizeRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/NormalizeRenderer.cs
@@ -20,7 +20,7 @@ namespace Markdig.Renderers.Normalize
         /// </summary>
         /// <param name="writer">The writer.</param>
         /// <param name="options">The normalize options</param>
-        public NormalizeRenderer(TextWriter writer, NormalizeOptions? options = null) : base(writer)
+        public NormalizeRenderer(TextWriter writer, NormalizeOptions? options = null, MarkdownParserContext? context = null) : base(writer, context)
         {
             Options = options ?? new NormalizeOptions();
             // Default block renderers

--- a/src/Markdig/Renderers/Roundtrip/RoundtripRenderer.cs
+++ b/src/Markdig/Renderers/Roundtrip/RoundtripRenderer.cs
@@ -20,7 +20,7 @@ namespace Markdig.Renderers.Roundtrip
         /// Initializes a new instance of the <see cref="RoundtripRenderer"/> class.
         /// </summary>
         /// <param name="writer">The writer.</param>
-        public RoundtripRenderer(TextWriter writer) : base(writer)
+        public RoundtripRenderer(TextWriter writer, MarkdownParserContext? context = null) : base(writer, context)
         {
             // Default block renderers
             ObjectRenderers.Add(new CodeBlockRenderer());

--- a/src/Markdig/Renderers/TextRendererBase.cs
+++ b/src/Markdig/Renderers/TextRendererBase.cs
@@ -25,11 +25,13 @@ namespace Markdig.Renderers
         /// </summary>
         /// <param name="writer">The writer.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        protected TextRendererBase(TextWriter writer)
+        protected TextRendererBase(TextWriter writer, MarkdownParserContext? context)
         {
             if (writer is null) ThrowHelper.ArgumentNullException_writer();
             this.writer = writer;
             this.writer.NewLine = "\n";
+
+            Context = context;
         }
 
         /// <summary>
@@ -51,6 +53,11 @@ namespace Markdig.Renderers
                 writer = value;
             }
         }
+
+        /// <summary>
+        /// Gets the renderer context or <c>null</c> if none is available.
+        /// </summary>
+        public MarkdownParserContext? Context { get; private set; }
 
         /// <summary>
         /// Renders the specified markdown object (returns the <see cref="Writer"/> as a render object).
@@ -111,7 +118,7 @@ namespace Markdig.Renderers
         /// Initializes a new instance of the <see cref="TextRendererBase{T}"/> class.
         /// </summary>
         /// <param name="writer">The writer.</param>
-        protected TextRendererBase(TextWriter writer) : base(writer)
+        protected TextRendererBase(TextWriter writer, MarkdownParserContext? context) : base(writer, context)
         {
 #if !NETCORE
             buffer = new char[1024];


### PR DESCRIPTION
Added MarkdownParserContext to Renderer.

I wrote my own LinkExtension render `TryLinkInlineRenderer`, and need context access from `HtmlRenderer`, that available only in parser.
```
    public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
    {
        if (renderer is HtmlRenderer htmlRenderer)
        {
            var inlineRenderer = htmlRenderer.ObjectRenderers.FindExact<LinkInlineRenderer>();
            if (inlineRenderer != null)
            {
                inlineRenderer.TryWriters.Remove(TryLinkInlineRenderer);
                inlineRenderer.TryWriters.Add(TryLinkInlineRenderer);
            }
        }
    }

    private bool TryLinkInlineRenderer(HtmlRenderer renderer, LinkInline link)
    {
        ...
       var propValue = (string?)renderer.Context?.Properties["PropName"];
        ...
    }
```

I think the context should be available both in the parser and in the render. This required minimal changes.
What do you think?