### PR TITLE
Diagrams are not correctly escaped

### DIFF
--- a/src/Markdig.Tests/Specs/DiagramsSpecs.generated.cs
+++ b/src/Markdig.Tests/Specs/DiagramsSpecs.generated.cs
@@ -35,14 +35,14 @@ namespace Markdig.Tests.Specs.Diagrams
             //
             // Should be rendered as:
             //     <div class="mermaid">graph TD;
-            //         A-->B;
-            //         A-->C;
-            //         B-->D;
-            //         C-->D;
+            //         A--&gt;B;
+            //         A--&gt;C;
+            //         B--&gt;D;
+            //         C--&gt;D;
             //     </div>
 
             Console.WriteLine("Example 1\nSection Extensions / Mermaid diagrams\n");
-            TestParser.TestSpec("```mermaid\ngraph TD;\n    A-->B;\n    A-->C;\n    B-->D;\n    C-->D;\n```", "<div class=\"mermaid\">graph TD;\n    A-->B;\n    A-->C;\n    B-->D;\n    C-->D;\n</div>", "diagrams|advanced");
+            TestParser.TestSpec("```mermaid\ngraph TD;\n    A-->B;\n    A-->C;\n    B-->D;\n    C-->D;\n```", "<div class=\"mermaid\">graph TD;\n    A--&gt;B;\n    A--&gt;C;\n    B--&gt;D;\n    C--&gt;D;\n</div>", "diagrams|advanced");
         }
     }
 
@@ -81,12 +81,12 @@ namespace Markdig.Tests.Specs.Diagrams
             //       methodB()
             //     |
             //       [subA]--[subB]
-            //       [subA]-:>[sub C]
+            //       [subA]-:&gt;[sub C]
             //     ]
             //     </div>
 
             Console.WriteLine("Example 2\nSection Extensions / nomnoml diagrams\n");
-            TestParser.TestSpec("```nomnoml\n[example|\n  propertyA: Int\n  propertyB: string\n|\n  methodA()\n  methodB()\n|\n  [subA]--[subB]\n  [subA]-:>[sub C]\n]\n```", "<div class=\"nomnoml\">[example|\n  propertyA: Int\n  propertyB: string\n|\n  methodA()\n  methodB()\n|\n  [subA]--[subB]\n  [subA]-:>[sub C]\n]\n</div>", "diagrams|advanced");
+            TestParser.TestSpec("```nomnoml\n[example|\n  propertyA: Int\n  propertyB: string\n|\n  methodA()\n  methodB()\n|\n  [subA]--[subB]\n  [subA]-:>[sub C]\n]\n```", "<div class=\"nomnoml\">[example|\n  propertyA: Int\n  propertyB: string\n|\n  methodA()\n  methodB()\n|\n  [subA]--[subB]\n  [subA]-:&gt;[sub C]\n]\n</div>", "diagrams|advanced");
         }
         // TODO: Add other text diagram languages
     }

--- a/src/Markdig.Tests/Specs/DiagramsSpecs.md
+++ b/src/Markdig.Tests/Specs/DiagramsSpecs.md
@@ -16,10 +16,10 @@ graph TD;
 ```
 .
 <div class="mermaid">graph TD;
-    A-->B;
-    A-->C;
-    B-->D;
-    C-->D;
+    A--&gt;B;
+    A--&gt;C;
+    B--&gt;D;
+    C--&gt;D;
 </div>
 ````````````````````````````````
 
@@ -49,7 +49,7 @@ Using a fenced code block with the `nomnoml` language info will output a `<div c
   methodB()
 |
   [subA]--[subB]
-  [subA]-:>[sub C]
+  [subA]-:&gt;[sub C]
 ]
 </div>
 ````````````````````````````````

--- a/src/Markdig/Renderers/Html/CodeBlockRenderer.cs
+++ b/src/Markdig/Renderers/Html/CodeBlockRenderer.cs
@@ -51,7 +51,7 @@ namespace Markdig.Renderers.Html
                             .Write('>');
                 }
 
-                renderer.WriteLeafRawLines(obj, true, true, true);
+                renderer.WriteLeafRawLines(obj, true, true);
 
                 if (renderer.EnableHtmlForBlock)
                 {


### PR DESCRIPTION
The issue with diagrams extension is that not all characters are escaped and thus invalid HTML could be generated.
A diagram sample is https://www.nomnoml.com/ that contains `<table>` in the diagram text.
Currently markdig is not escaping `>` but is escaping `<`.
This results in parsing errors in mermaid and nomnoml.

`CodeBlockRenderer` uses `softEsacape=false` and with `BlocksAsDiv` it uses `softEscape=true`.
According to documentation `BlocksAsDiv` should not change escaping behavior.

Please let me know when there are questions or something is missing.