### PR TITLE
Fix link reference definition parse bug with title and CRLF

### DIFF
--- a/src/Markdig.Tests/TestPlayParser.cs
+++ b/src/Markdig.Tests/TestPlayParser.cs
@@ -15,11 +15,17 @@ namespace Markdig.Tests
         [Test]
         public void TestLinksWithCarriageReturn()
         {
-            {
-                var text = "[Link 1][link-1], [link 2][link-2].\r\n\r\n[link-1]: https://example.com\r\n[link-2]: https://example.com";
-                var result = Markdown.ToHtml(text).TrimEnd();
-                Assert.AreEqual("<p><a href=\"https://example.com\">Link 1</a>, <a href=\"https://example.com\">link 2</a>.</p>", result);
-            }
+            var text = "[Link 1][link-1], [link 2][link-2].\r\n\r\n[link-1]: https://example.com\r\n[link-2]: https://example.com";
+            var result = Markdown.ToHtml(text).TrimEnd();
+            Assert.AreEqual("<p><a href=\"https://example.com\">Link 1</a>, <a href=\"https://example.com\">link 2</a>.</p>", result);
+        }
+
+        [Test]
+        public void TestLinksWithTitleAndCarriageReturn()
+        {
+            var text = "[Link 1][link-1], [link 2][link-2].\r\n\r\n[link-1]: https://example.com \"title 1\" \r\n[link-2]: https://example.com \"title 2\"";
+            var result = Markdown.ToHtml(text).TrimEnd();
+            Assert.AreEqual("<p><a href=\"https://example.com\" title=\"title 1\">Link 1</a>, <a href=\"https://example.com\" title=\"title 2\">link 2</a>.</p>", result);
         }
 
         [Test]

--- a/src/Markdig/Helpers/LinkHelper.cs
+++ b/src/Markdig/Helpers/LinkHelper.cs
@@ -606,7 +606,7 @@ namespace Markdig.Helpers
                             hasOnlyWhiteSpacesSinceLastLine = 1;
                         }
                     }
-                    else if (c != '\n' && c != '\r' && (c != '\r' && text.PeekChar() != '\n'))
+                    else if (c != '\n' && c != '\r' && text.PeekChar() != '\n')
                     {
                         hasOnlyWhiteSpacesSinceLastLine = 0;
                     }
@@ -700,7 +700,7 @@ namespace Markdig.Helpers
                             hasOnlyWhiteSpacesSinceLastLine = 1;
                         }
                     }
-                    else if (c != '\n' && c != '\r' && (c != '\r' && text.PeekChar() != '\n'))
+                    else if (c != '\n' && c != '\r' && text.PeekChar() != '\n')
                     {
                         hasOnlyWhiteSpacesSinceLastLine = 0;
                     }
@@ -1141,7 +1141,7 @@ namespace Markdig.Helpers
                 c = text.NextChar();
             }
 
-            if (c != '\0' && c != '\n')
+            if (c != '\0' && c != '\n' && c != '\r' && text.PeekChar() != '\n')
             {
                 // If we were able to parse the url but the title doesn't end with space, 
                 // we are still returning a valid definition
@@ -1156,6 +1156,11 @@ namespace Markdig.Helpers
                 url = null;
                 title = null;
                 return false;
+            }
+
+            if (c == '\r' && text.PeekChar() == '\n')
+            {
+                text.SkipChar();
             }
 
             return true;
@@ -1276,7 +1281,7 @@ namespace Markdig.Helpers
                 c = text.NextChar();
             }
 
-            if (c != '\0' && c != '\n' && c != '\r' && (c != '\r' && text.PeekChar() != '\n'))
+            if (c != '\0' && c != '\n' && c != '\r' && text.PeekChar() != '\n')
             {
                 // If we were able to parse the url but the title doesn't end with space, 
                 // we are still returning a valid definition
@@ -1307,6 +1312,7 @@ namespace Markdig.Helpers
                 else if (c == '\r' && text.PeekChar() == '\n')
                 {
                     newLine = NewLine.CarriageReturnLineFeed;
+                    text.SkipChar();
                 }
                 else if (c == '\r')
                 {


### PR DESCRIPTION
Fix LinkReferenceDefinition parse bug when CRLF is used as line ending: https://github.com/dotnet/docfx/issues/7850