### PR TITLE
Drop .netcoreapp2.1 target and cross target .net6.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,7 +103,7 @@ You can have a look at the [MarkdownExtensions](https://github.com/lunet-io/mark
 
 ## Build
 
-In order to build Markdig, you need to install [.NET Core RTM](https://www.microsoft.com/net/core)
+In order to build Markdig, you need to install [.NET 6.0](https://dotnet.microsoft.com/en-us/download)
 
 ## License
 

--- a/src/Markdig.Benchmarks/Markdig.Benchmarks.csproj
+++ b/src/Markdig.Benchmarks/Markdig.Benchmarks.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net471</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>

--- a/src/Markdig/Helpers/CharacterMap.cs
+++ b/src/Markdig/Helpers/CharacterMap.cs
@@ -107,7 +107,7 @@ namespace Markdig.Helpers
         {
             if (nonAsciiMap is null)
             {
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
                 ref char textRef = ref Unsafe.AsRef(in text.GetPinnableReference());
                 for (; start <= end; start++)
                 {
@@ -154,7 +154,7 @@ namespace Markdig.Helpers
 
         private int IndexOfOpeningCharacterNonAscii(string text, int start, int end)
         {
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             ref char textRef = ref Unsafe.AsRef(in text.GetPinnableReference());
             for (int i = start; i <= end; i++)
             {

--- a/src/Markdig/Markdig.targets
+++ b/src/Markdig/Markdig.targets
@@ -8,7 +8,7 @@
     <Authors>Alexandre Mutel</Authors>
     <!-- Markdig.Wpf still supports net452, a target still supported by by Microsoft until January 10, 2023 -->
     <!-- see: https://github.com/xoofx/markdig/pull/466 -->
-    <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net6.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <PackageTags>Markdown CommonMark md html md2html</PackageTags>
     <PackageReleaseNotes>https://github.com/lunet-io/markdig/blob/master/changelog.md</PackageReleaseNotes>
@@ -39,14 +39,14 @@
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
+  </PropertyGroup>
+  
   <ItemGroup>
     <None Include="../../img/markdig.png" Pack="true" PackagePath="" />
     <None Include="../../readme.md" Pack="true" PackagePath="/"/>

--- a/src/Markdig/Markdig.targets
+++ b/src/Markdig/Markdig.targets
@@ -17,7 +17,7 @@
     <PackageIcon>markdig.png</PackageIcon>
     <PackageProjectUrl>https://github.com/lunet-io/markdig</PackageProjectUrl>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>9</LangVersion>
+    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Markdig/Polyfills/NullableAttributes.cs
+++ b/src/Markdig/Polyfills/NullableAttributes.cs
@@ -5,7 +5,7 @@
 
 namespace System.Diagnostics.CodeAnalysis
 {
-#if !NETCORE || NETCOREAPP2_1
+#if !NETCORE
     internal sealed class DoesNotReturnAttribute : Attribute { }
 
     [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]

--- a/src/Markdig/Polyfills/NullableAttributes.cs
+++ b/src/Markdig/Polyfills/NullableAttributes.cs
@@ -17,6 +17,7 @@ namespace System.Diagnostics.CodeAnalysis
     }
 #endif
 
+#if !NET5_0_OR_GREATER
     internal sealed class MemberNotNullAttribute : Attribute
     {
         public MemberNotNullAttribute(string member) => Members = new[] { member };
@@ -25,4 +26,5 @@ namespace System.Diagnostics.CodeAnalysis
 
         public string[] Members { get; }
     }
+#endif
 }


### PR DESCRIPTION
.NETCOREAPP2.1 is no longer supported & .NET6.0 will provide us with with 3 years of support.