### PR TITLE
Improvements when TrackTrivia is disabled

### DIFF
--- a/src/Markdig/Helpers/StringSlice.cs
+++ b/src/Markdig/Helpers/StringSlice.cs
@@ -82,6 +82,15 @@ namespace Markdig.Helpers
             NewLine = newLine;
         }
 
+        // Internal ctor to skip the null check
+        internal StringSlice(string text, int start, int end, NewLine newLine, bool dummy)
+        {
+            Text = text;
+            Start = start;
+            End = end;
+            NewLine = newLine;
+        }
+
         /// <summary>
         /// The text of this slice.
         /// </summary>

--- a/src/Markdig/Parsers/FencedBlockParserBase.cs
+++ b/src/Markdig/Parsers/FencedBlockParserBase.cs
@@ -332,9 +332,13 @@ namespace Markdig.Parsers
 
                 var fencedBlock = (IFencedBlock)block;
                 fencedBlock.ClosingFencedCharCount = closingCount;
-                fencedBlock.NewLine = processor.Line.NewLine;
-                fencedBlock.TriviaBeforeClosingFence = processor.UseTrivia(sourcePosition - 1);
-                fencedBlock.TriviaAfter = new StringSlice(processor.Line.Text, lastFenceCharPosition, endBeforeTrim);
+
+                if (processor.TrackTrivia)
+                {
+                    fencedBlock.NewLine = processor.Line.NewLine;
+                    fencedBlock.TriviaBeforeClosingFence = processor.UseTrivia(sourcePosition - 1);
+                    fencedBlock.TriviaAfter = new StringSlice(processor.Line.Text, lastFenceCharPosition, endBeforeTrim);
+                }
 
                 // Don't keep the last line
                 return BlockState.BreakDiscard;

--- a/src/Markdig/Parsers/FencedCodeBlockParser.cs
+++ b/src/Markdig/Parsers/FencedCodeBlockParser.cs
@@ -26,13 +26,19 @@ namespace Markdig.Parsers
 
         protected override FencedCodeBlock CreateFencedBlock(BlockProcessor processor)
         {
-            return new FencedCodeBlock(this)
+            var codeBlock = new FencedCodeBlock(this)
             {
                 IndentCount = processor.Indent,
-                LinesBefore = processor.UseLinesBefore(),
-                TriviaBefore = processor.UseTrivia(processor.Start - 1),
-                NewLine = processor.Line.NewLine,
             };
+
+            if (processor.TrackTrivia)
+            {
+                codeBlock.LinesBefore = processor.UseLinesBefore();
+                codeBlock.TriviaBefore = processor.UseTrivia(processor.Start - 1);
+                codeBlock.NewLine = processor.Line.NewLine;
+            }
+
+            return codeBlock;
         }
 
         public override BlockState TryContinue(BlockProcessor processor, Block block)

--- a/src/Markdig/Parsers/HeadingBlockParser.cs
+++ b/src/Markdig/Parsers/HeadingBlockParser.cs
@@ -82,19 +82,24 @@ namespace Markdig.Parsers
                 var headingBlock = new HeadingBlock(this)
                 {
                     HeaderChar = matchingChar,
-                    TriviaAfterAtxHeaderChar = trivia,
                     Level = leadingCount,
                     Column = column,
                     Span = { Start = sourcePosition },
-                    TriviaBefore = processor.UseTrivia(sourcePosition - 1),
-                    LinesBefore = processor.UseLinesBefore(),
-                    NewLine = processor.Line.NewLine,
                 };
-                processor.NewBlocks.Push(headingBlock);
-                if (!processor.TrackTrivia)
+
+                if (processor.TrackTrivia)
+                {
+                    headingBlock.TriviaAfterAtxHeaderChar = trivia;
+                    headingBlock.TriviaBefore = processor.UseTrivia(sourcePosition - 1);
+                    headingBlock.LinesBefore = processor.UseLinesBefore();
+                    headingBlock.NewLine = processor.Line.NewLine;
+                }
+                else
                 {
                     processor.GoToColumn(column + leadingCount + 1);
                 }
+
+                processor.NewBlocks.Push(headingBlock);
 
                 // Gives a chance to parse attributes
                 TryParseAttributes?.Invoke(processor, ref processor.Line, headingBlock);

--- a/src/Markdig/Parsers/HtmlBlockParser.cs
+++ b/src/Markdig/Parsers/HtmlBlockParser.cs
@@ -270,16 +270,22 @@ namespace Markdig.Parsers
 
         private BlockState CreateHtmlBlock(BlockProcessor state, HtmlBlockType type, int startColumn, int startPosition)
         {
-            state.NewBlocks.Push(new HtmlBlock(this)
+            var htmlBlock = new HtmlBlock(this)
             {
                 Column = startColumn,
                 Type = type,
                 // By default, setup to the end of line
                 Span = new SourceSpan(startPosition, startPosition + state.Line.End),
                 //BeforeWhitespace = state.PopBeforeWhitespace(startPosition - 1),
-                LinesBefore = state.UseLinesBefore(),
-                NewLine = state.Line.NewLine,
-            });
+            };
+
+            if (state.TrackTrivia)
+            {
+                htmlBlock.LinesBefore = state.UseLinesBefore();
+                htmlBlock.NewLine = state.Line.NewLine;
+            }
+
+            state.NewBlocks.Push(htmlBlock);
             return BlockState.Continue;
         }
 

--- a/src/Markdig/Parsers/IndentedCodeBlockParser.cs
+++ b/src/Markdig/Parsers/IndentedCodeBlockParser.cs
@@ -36,9 +36,14 @@ namespace Markdig.Parsers
                 {
                     Column = processor.Column,
                     Span = new SourceSpan(processor.Start, processor.Line.End),
-                    LinesBefore = processor.UseLinesBefore(),
-                    NewLine = processor.Line.NewLine,
                 };
+
+                if (processor.TrackTrivia)
+                {
+                    codeBlock.LinesBefore = processor.UseLinesBefore();
+                    codeBlock.NewLine = processor.Line.NewLine;
+                }
+
                 var codeBlockLine = new CodeBlockLine
                 {
                     TriviaBefore = processor.UseTrivia(sourceStartPosition - 1)
@@ -68,8 +73,12 @@ namespace Markdig.Parsers
                             if (line.Slice.IsEmpty)
                             {
                                 codeBlock.Lines.RemoveAt(i);
-                                processor.LinesBefore ??= new List<StringSlice>();
-                                processor.LinesBefore.Add(line.Slice);
+
+                                if (processor.TrackTrivia)
+                                {
+                                    processor.LinesBefore ??= new List<StringSlice>();
+                                    processor.LinesBefore.Add(line.Slice);
+                                }
                             }
                             else
                             {
@@ -92,12 +101,15 @@ namespace Markdig.Parsers
 
                 // lines
                 var cb = (CodeBlock)block;
-                var codeBlockLine = new CodeBlockLine
-                {
-                    TriviaBefore = processor.UseTrivia(processor.Start - 1)
-                };
+                var codeBlockLine = new CodeBlockLine();
+
                 cb.CodeBlockLines.Add(codeBlockLine);
-                cb.NewLine = processor.Line.NewLine; // ensure block newline is last newline
+
+                if (processor.TrackTrivia)
+                {
+                    codeBlockLine.TriviaBefore = processor.UseTrivia(processor.Start - 1);
+                    cb.NewLine = processor.Line.NewLine; // ensure block newline is last newline
+                }
             }
 
             return BlockState.Continue;

--- a/src/Markdig/Parsers/Inlines/CodeInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/CodeInlineParser.cs
@@ -113,15 +113,21 @@ namespace Markdig.Parsers.Inlines
                 int delimiterCount = Math.Min(openSticks, closeSticks);
                 var spanStart = processor.GetSourcePosition(startPosition, out int line, out int column);
                 var spanEnd = processor.GetSourcePosition(slice.Start - 1);
-                processor.Inline = new CodeInline(content)
+                var codeInline = new CodeInline(content)
                 {
                     Delimiter = match,
-                    ContentWithTrivia = new StringSlice(slice.Text, contentStart, contentEnd - 1),
                     Span = new SourceSpan(spanStart, spanEnd),
                     Line = line,
                     Column = column,
                     DelimiterCount = delimiterCount,
                 };
+
+                if (processor.TrackTrivia)
+                {
+                    codeInline.ContentWithTrivia = new StringSlice(slice.Text, contentStart, contentEnd - 1);
+                }
+
+                processor.Inline = codeInline;
                 isMatching = true;
             }
 

--- a/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
@@ -5,6 +5,7 @@
 using Markdig.Helpers;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Markdig.Parsers.Inlines
 {
@@ -233,74 +234,18 @@ namespace Markdig.Parsers.Inlines
 
             if (text.CurrentChar == '(')
             {
+                LinkInline? link = null;
+
                 if (inlineState.TrackTrivia)
                 {
-                    if (LinkHelper.TryParseInlineLinkTrivia(
-                        ref text,
-                        out string? url,
-                        out SourceSpan unescapedUrlSpan,
-                        out string? title,
-                        out SourceSpan unescapedTitleSpan,
-                        out char titleEnclosingCharacter,
-                        out SourceSpan linkSpan,
-                        out SourceSpan titleSpan,
-                        out SourceSpan triviaBeforeLink,
-                        out SourceSpan triviaAfterLink,
-                        out SourceSpan triviaAfterTitle,
-                        out bool urlHasPointyBrackets))
-                    {
-                        var wsBeforeLink = new StringSlice(text.Text, triviaBeforeLink.Start, triviaBeforeLink.End);
-                        var wsAfterLink = new StringSlice(text.Text, triviaAfterLink.Start, triviaAfterLink.End);
-                        var wsAfterTitle = new StringSlice(text.Text, triviaAfterTitle.Start, triviaAfterTitle.End);
-                        var unescapedUrl = new StringSlice(text.Text, unescapedUrlSpan.Start, unescapedUrlSpan.End);
-                        var unescapedTitle = new StringSlice(text.Text, unescapedTitleSpan.Start, unescapedTitleSpan.End);
-                        // Inline Link
-                        var link = new LinkInline()
-                        {
-                            TriviaBeforeUrl = wsBeforeLink,
-                            Url = HtmlHelper.Unescape(url),
-                            UnescapedUrl = unescapedUrl,
-                            UrlHasPointyBrackets = urlHasPointyBrackets,
-                            TriviaAfterUrl = wsAfterLink,
-                            Title = HtmlHelper.Unescape(title),
-                            UnescapedTitle = unescapedTitle,
-                            TitleEnclosingCharacter = titleEnclosingCharacter,
-                            TriviaAfterTitle = wsAfterTitle,
-                            IsImage = openParent.IsImage,
-                            LabelSpan = openParent.LabelSpan,
-                            UrlSpan = inlineState.GetSourcePositionFromLocalSpan(linkSpan),
-                            TitleSpan = inlineState.GetSourcePositionFromLocalSpan(titleSpan),
-                            Span = new SourceSpan(openParent.Span.Start, inlineState.GetSourcePosition(text.Start - 1)),
-                            Line = openParent.Line,
-                            Column = openParent.Column,
-                        };
-
-                        openParent.ReplaceBy(link);
-                        // Notifies processor as we are creating an inline locally
-                        inlineState.Inline = link;
-
-                        // Process emphasis delimiters
-                        inlineState.PostProcessInlines(0, link, null, false);
-
-                        // If we have a link (and not an image),
-                        // we also set all [ delimiters before the opening delimiter to inactive.
-                        // (This will prevent us from getting links within links.)
-                        if (!openParent.IsImage)
-                        {
-                            MarkParentAsInactive(parentDelimiter);
-                        }
-
-                        link.IsClosed = true;
-
-                        return true;
-                    }
+                    link = TryParseInlineLinkTrivia(ref text, inlineState, openParent);
                 }
                 else
                 {
                     if (LinkHelper.TryParseInlineLink(ref text, out string? url, out string? title, out SourceSpan linkSpan, out SourceSpan titleSpan))
                     {
                         // Inline Link
-                        var link = new LinkInline()
+                        link = new LinkInline()
                         {
                             Url = HtmlHelper.Unescape(url),
                             Title = HtmlHelper.Unescape(title),
@@ -312,26 +257,29 @@ namespace Markdig.Parsers.Inlines
                             Line = openParent.Line,
                             Column = openParent.Column,
                         };
-
-                        openParent.ReplaceBy(link);
-                        // Notifies processor as we are creating an inline locally
-                        inlineState.Inline = link;
-
-                        // Process emphasis delimiters
-                        inlineState.PostProcessInlines(0, link, null, false);
-
-                        // If we have a link (and not an image),
-                        // we also set all [ delimiters before the opening delimiter to inactive.
-                        // (This will prevent us from getting links within links.)
-                        if (!openParent.IsImage)
-                        {
-                            MarkParentAsInactive(parentDelimiter);
-                        }
-
-                        link.IsClosed = true;
-
-                        return true;
                     }
+                }
+
+                if (link is not null)
+                {
+                    openParent.ReplaceBy(link);
+                    // Notifies processor as we are creating an inline locally
+                    inlineState.Inline = link;
+
+                    // Process emphasis delimiters
+                    inlineState.PostProcessInlines(0, link, null, false);
+
+                    // If we have a link (and not an image),
+                    // we also set all [ delimiters before the opening delimiter to inactive.
+                    // (This will prevent us from getting links within links.)
+                    if (!openParent.IsImage)
+                    {
+                        MarkParentAsInactive(parentDelimiter);
+                    }
+
+                    link.IsClosed = true;
+
+                    return true;
                 }
 
                 text = savedText;
@@ -339,7 +287,6 @@ namespace Markdig.Parsers.Inlines
 
             var labelSpan = SourceSpan.Empty;
             string? label = null;
-            SourceSpan labelWithTrivia = SourceSpan.Empty;
             bool isLabelSpanLocal = true;
 
             bool isShortcut = false;
@@ -363,9 +310,10 @@ namespace Markdig.Parsers.Inlines
                 label = openParent.Label;
                 isShortcut = true;
             }
+
             if (label != null || LinkHelper.TryParseLabelTrivia(ref text, true, out label, out labelSpan))
             {
-                labelWithTrivia = new SourceSpan(labelSpan.Start, labelSpan.End);
+                SourceSpan labelWithTrivia = new SourceSpan(labelSpan.Start, labelSpan.End);
                 if (isLabelSpanLocal)
                 {
                     labelSpan = inlineState.GetSourcePositionFromLocalSpan(labelSpan);
@@ -399,9 +347,55 @@ namespace Markdig.Parsers.Inlines
 
             inlineState.Inline = openParent.ReplaceBy(literal);
             return false;
+
+            static LinkInline? TryParseInlineLinkTrivia(ref StringSlice text, InlineProcessor inlineState, LinkDelimiterInline openParent)
+            {
+                if (LinkHelper.TryParseInlineLinkTrivia(
+                    ref text,
+                    out string? url,
+                    out SourceSpan unescapedUrlSpan,
+                    out string? title,
+                    out SourceSpan unescapedTitleSpan,
+                    out char titleEnclosingCharacter,
+                    out SourceSpan linkSpan,
+                    out SourceSpan titleSpan,
+                    out SourceSpan triviaBeforeLink,
+                    out SourceSpan triviaAfterLink,
+                    out SourceSpan triviaAfterTitle,
+                    out bool urlHasPointyBrackets))
+                {
+                    var wsBeforeLink = new StringSlice(text.Text, triviaBeforeLink.Start, triviaBeforeLink.End);
+                    var wsAfterLink = new StringSlice(text.Text, triviaAfterLink.Start, triviaAfterLink.End);
+                    var wsAfterTitle = new StringSlice(text.Text, triviaAfterTitle.Start, triviaAfterTitle.End);
+                    var unescapedUrl = new StringSlice(text.Text, unescapedUrlSpan.Start, unescapedUrlSpan.End);
+                    var unescapedTitle = new StringSlice(text.Text, unescapedTitleSpan.Start, unescapedTitleSpan.End);
+
+                    return new LinkInline()
+                    {
+                        TriviaBeforeUrl = wsBeforeLink,
+                        Url = HtmlHelper.Unescape(url),
+                        UnescapedUrl = unescapedUrl,
+                        UrlHasPointyBrackets = urlHasPointyBrackets,
+                        TriviaAfterUrl = wsAfterLink,
+                        Title = HtmlHelper.Unescape(title),
+                        UnescapedTitle = unescapedTitle,
+                        TitleEnclosingCharacter = titleEnclosingCharacter,
+                        TriviaAfterTitle = wsAfterTitle,
+                        IsImage = openParent.IsImage,
+                        LabelSpan = openParent.LabelSpan,
+                        UrlSpan = inlineState.GetSourcePositionFromLocalSpan(linkSpan),
+                        TitleSpan = inlineState.GetSourcePositionFromLocalSpan(titleSpan),
+                        Span = new SourceSpan(openParent.Span.Start, inlineState.GetSourcePosition(text.Start - 1)),
+                        Line = openParent.Line,
+                        Column = openParent.Column,
+                    };
+                }
+
+                return null;
+            }
         }
 
-        private void MarkParentAsInactive(Inline? inline)
+        private static void MarkParentAsInactive(Inline? inline)
         {
             while (inline != null)
             {

--- a/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
@@ -138,18 +138,13 @@ namespace Markdig.Parsers.Inlines
             // Create a default link if the callback was not found
             if (link is null)
             {
-                var labelWithTrivia = new StringSlice(text.Text, labelWithriviaSpan.Start, labelWithriviaSpan.End);
                 // Inline Link
-                link = new LinkInline()
+                var linkInline = new LinkInline()
                 {
                     Url = HtmlHelper.Unescape(linkRef.Url),
                     Title = HtmlHelper.Unescape(linkRef.Title),
                     Label = label,
                     LabelSpan = labelSpan,
-                    LabelWithTrivia = labelWithTrivia,
-                    LinkRefDefLabel = linkRef.Label,
-                    LinkRefDefLabelWithTrivia = linkRef.LabelWithTrivia,
-                    LocalLabel = localLabel,
                     UrlSpan = linkRef.UrlSpan,
                     IsImage = parent.IsImage,
                     IsShortcut = isShortcut,
@@ -158,6 +153,16 @@ namespace Markdig.Parsers.Inlines
                     Line = parent.Line,
                     Column = parent.Column,
                 };
+
+                if (state.TrackTrivia)
+                {
+                    linkInline.LabelWithTrivia = new StringSlice(text.Text, labelWithriviaSpan.Start, labelWithriviaSpan.End);
+                    linkInline.LinkRefDefLabel = linkRef.Label;
+                    linkInline.LinkRefDefLabelWithTrivia = linkRef.LabelWithTrivia;
+                    linkInline.LocalLabel = localLabel;
+                }
+
+                link = linkInline;
             }
 
             if (link is ContainerInline containerLink)

--- a/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
@@ -79,18 +79,23 @@ namespace Markdig.Parsers.Inlines
 
                     // Else we insert a LinkDelimiter
                     slice.SkipChar();
-                    var labelWithTrivia = new StringSlice(slice.Text, labelWithTriviaSpan.Start, labelWithTriviaSpan.End);
-                    processor.Inline = new LinkDelimiterInline(this)
+                    var linkDelimiter = new LinkDelimiterInline(this)
                     {
                         Type = DelimiterType.Open,
                         Label = label,
-                        LabelWithTrivia = labelWithTrivia,
                         LabelSpan = processor.GetSourcePositionFromLocalSpan(labelSpan),
                         IsImage = isImage,
                         Span = new SourceSpan(startPosition, processor.GetSourcePosition(slice.Start - 1)),
                         Line = line,
                         Column = column
                     };
+
+                    if (processor.TrackTrivia)
+                    {
+                        linkDelimiter.LabelWithTrivia = new StringSlice(slice.Text, labelWithTriviaSpan.Start, labelWithTriviaSpan.End);
+                    }
+
+                    processor.Inline = linkDelimiter;
                     return true;
 
                 case ']':

--- a/src/Markdig/Parsers/ListBlockParser.cs
+++ b/src/Markdig/Parsers/ListBlockParser.cs
@@ -93,8 +93,12 @@ namespace Markdig.Parsers
                 {
                     // TODO: We remove the thematic break, as it will be created later, but this is inefficient, try to find another way
                     var thematicBreak = processor.NewBlocks.Pop();
-                    var linesBefore = thematicBreak.LinesBefore;
-                    processor.LinesBefore = linesBefore;
+
+                    if (processor.TrackTrivia)
+                    {
+                        processor.LinesBefore = thematicBreak.LinesBefore;
+                    }
+
                     return BlockState.None;
                 }
             }
@@ -276,12 +280,17 @@ namespace Markdig.Parsers
                 Column = initColumn,
                 ColumnWidth = columnWidth,
                 Order = order,
-                SourceBullet = listInfo.SourceBullet,
-                TriviaBefore = triviaBefore,
                 Span = new SourceSpan(sourcePosition, sourceEndPosition),
-                LinesBefore = state.UseLinesBefore(),
-                NewLine = state.Line.NewLine,
             };
+
+            if (state.TrackTrivia)
+            {
+                newListItem.TriviaBefore = triviaBefore;
+                newListItem.LinesBefore = state.UseLinesBefore();
+                newListItem.NewLine = state.Line.NewLine;
+                newListItem.SourceBullet = listInfo.SourceBullet;
+            }
+
             state.NewBlocks.Push(newListItem);
 
             if (currentParent != null)
@@ -313,8 +322,13 @@ namespace Markdig.Parsers
                     OrderedDelimiter = listInfo.OrderedDelimiter,
                     DefaultOrderedStart = listInfo.DefaultOrderedStart,
                     OrderedStart = listInfo.OrderedStart,
-                    LinesBefore = state.UseLinesBefore(),
                 };
+
+                if (state.TrackTrivia)
+                {
+                    newList.LinesBefore = state.UseLinesBefore();
+                }
+
                 state.NewBlocks.Push(newList);
             }
             return BlockState.Continue;

--- a/src/Markdig/Parsers/MarkdownParser.cs
+++ b/src/Markdig/Parsers/MarkdownParser.cs
@@ -43,8 +43,8 @@ namespace Markdig.Parsers
 
             if (pipeline.PreciseSourceLocation)
             {
-                int roughLineCountEstimate = text.Length / 40;
-                roughLineCountEstimate = Math.Min(4, Math.Max(512, roughLineCountEstimate));
+                int roughLineCountEstimate = text.Length / 32;
+                roughLineCountEstimate = Math.Max(4, Math.Min(512, roughLineCountEstimate));
                 document.LineStartIndexes = new List<int>(roughLineCountEstimate);
             }
 

--- a/src/Markdig/Parsers/ParagraphBlockParser.cs
+++ b/src/Markdig/Parsers/ParagraphBlockParser.cs
@@ -23,13 +23,19 @@ namespace Markdig.Parsers
             }
 
             // We continue trying to match by default
-            processor.NewBlocks.Push(new ParagraphBlock(this)
+            var paragraph = new ParagraphBlock(this)
             {
                 Column = processor.Column,
                 Span = new SourceSpan(processor.Line.Start, processor.Line.End),
-                LinesBefore = processor.UseLinesBefore(),
-                NewLine = processor.Line.NewLine,
-            });
+            };
+
+            if (processor.TrackTrivia)
+            {
+                paragraph.LinesBefore = processor.UseLinesBefore();
+                paragraph.NewLine = processor.Line.NewLine;
+            }
+
+            processor.NewBlocks.Push(paragraph);
             return BlockState.Continue;
         }
 
@@ -128,15 +134,19 @@ namespace Markdig.Parsers
                         Span = new SourceSpan(paragraph.Span.Start, line.Start),
                         Level = level,
                         Lines = paragraph.Lines,
-                        TriviaBefore = state.UseTrivia(sourcePosition - 1), // remove dashes
-                        TriviaAfter = new StringSlice(state.Line.Text, state.Start, line.End),
-                        LinesBefore = paragraph.LinesBefore,
-                        NewLine = state.Line.NewLine,
                         IsSetext = true,
                         HeaderCharCount = count,
-                        SetextNewline = paragraph.NewLine,
                     };
-                    if (!state.TrackTrivia)
+
+                    if (state.TrackTrivia)
+                    {
+                        heading.LinesBefore = paragraph.LinesBefore;
+                        heading.TriviaBefore = state.UseTrivia(sourcePosition - 1); // remove dashes
+                        heading.TriviaAfter = new StringSlice(state.Line.Text, state.Start, line.End);
+                        heading.NewLine = state.Line.NewLine;
+                        heading.SetextNewline = paragraph.NewLine;
+                    }
+                    else
                     {
                         heading.Lines.Trim();
                     }

--- a/src/Markdig/Parsers/QuoteBlockParser.cs
+++ b/src/Markdig/Parsers/QuoteBlockParser.cs
@@ -41,8 +41,12 @@ namespace Markdig.Parsers
                 QuoteChar = quoteChar,
                 Column = column,
                 Span = new SourceSpan(sourcePosition, processor.Line.End),
-                LinesBefore = processor.UseLinesBefore()
             };
+
+            if (processor.TrackTrivia)
+            {
+                quoteBlock.LinesBefore = processor.UseLinesBefore();
+            }
 
             bool hasSpaceAfterQuoteChar = false;
             if (c == ' ')
@@ -56,28 +60,34 @@ namespace Markdig.Parsers
                 processor.NextColumn();
             }
 
-            var triviaBefore = processor.UseTrivia(sourcePosition - 1);
-            StringSlice triviaAfter = StringSlice.Empty;
-            bool wasEmptyLine = false;
-            if (processor.Line.IsEmptyOrWhitespace())
+            if (processor.TrackTrivia)
             {
-                processor.TriviaStart = processor.Start;
-                triviaAfter = processor.UseTrivia(processor.Line.End);
-                wasEmptyLine = true;
+                var triviaBefore = processor.UseTrivia(sourcePosition - 1);
+                StringSlice triviaAfter = StringSlice.Empty;
+                bool wasEmptyLine = false;
+                if (processor.Line.IsEmptyOrWhitespace())
+                {
+                    processor.TriviaStart = processor.Start;
+                    triviaAfter = processor.UseTrivia(processor.Line.End);
+                    wasEmptyLine = true;
+                }
+
+                if (!wasEmptyLine)
+                {
+                    processor.TriviaStart = processor.Start;
+                }
+
+                quoteBlock.QuoteLines.Add(new QuoteBlockLine
+                {
+                    TriviaBefore = triviaBefore,
+                    TriviaAfter = triviaAfter,
+                    QuoteChar = true,
+                    HasSpaceAfterQuoteChar = hasSpaceAfterQuoteChar,
+                    NewLine = processor.Line.NewLine,
+                });
             }
-            quoteBlock.QuoteLines.Add(new QuoteBlockLine
-            {
-                TriviaBefore = triviaBefore,
-                TriviaAfter = triviaAfter,
-                QuoteChar = true,
-                HasSpaceAfterQuoteChar = hasSpaceAfterQuoteChar,
-                NewLine = processor.Line.NewLine,
-            });
+
             processor.NewBlocks.Push(quoteBlock);
-            if (!wasEmptyLine)
-            {
-                processor.TriviaStart = processor.Start;
-            }
             return BlockState.Continue;
         }
 
@@ -94,7 +104,6 @@ namespace Markdig.Parsers
             // 5.1 Block quotes 
             // A block quote marker consists of 0-3 spaces of initial indent, plus (a) the character > together with a following space, or (b) a single character > not followed by a space.
             var c = processor.CurrentChar;
-            bool hasSpaceAfterQuoteChar = false;
             if (c != quote.QuoteChar)
             {
                 if (processor.IsBlankLine)
@@ -103,14 +112,19 @@ namespace Markdig.Parsers
                 }
                 else
                 {
-                    quote.QuoteLines.Add(new QuoteBlockLine
+                    if (processor.TrackTrivia)
                     {
-                        QuoteChar = false,
-                        NewLine = processor.Line.NewLine,
-                    });
+                        quote.QuoteLines.Add(new QuoteBlockLine
+                        {
+                            QuoteChar = false,
+                            NewLine = processor.Line.NewLine,
+                        });
+                    }
                     return BlockState.None;
                 }
             }
+
+            bool hasSpaceAfterQuoteChar = false;
             c = processor.NextChar(); // Skip quote marker char
             if (c == ' ')
             {
@@ -122,28 +136,33 @@ namespace Markdig.Parsers
             {
                 processor.NextColumn();
             }
-            var TriviaSpaceBefore = processor.UseTrivia(sourcePosition - 1);
-            StringSlice triviaAfter = StringSlice.Empty;
-            bool wasEmptyLine = false;
-            if (processor.Line.IsEmptyOrWhitespace())
-            {
-                processor.TriviaStart = processor.Start;
-                triviaAfter = processor.UseTrivia(processor.Line.End);
-                wasEmptyLine = true;
-            }
-            quote.QuoteLines.Add(new QuoteBlockLine
-            {
-                QuoteChar = true,
-                HasSpaceAfterQuoteChar = hasSpaceAfterQuoteChar,
-                TriviaBefore = TriviaSpaceBefore,
-                TriviaAfter = triviaAfter,
-                NewLine = processor.Line.NewLine,
-            });
 
-            if (!wasEmptyLine)
+            if (processor.TrackTrivia)
             {
-                processor.TriviaStart = processor.Start;
+                var triviaSpaceBefore = processor.UseTrivia(sourcePosition - 1);
+                StringSlice triviaAfter = StringSlice.Empty;
+                bool wasEmptyLine = false;
+                if (processor.Line.IsEmptyOrWhitespace())
+                {
+                    processor.TriviaStart = processor.Start;
+                    triviaAfter = processor.UseTrivia(processor.Line.End);
+                    wasEmptyLine = true;
+                }
+                quote.QuoteLines.Add(new QuoteBlockLine
+                {
+                    QuoteChar = true,
+                    HasSpaceAfterQuoteChar = hasSpaceAfterQuoteChar,
+                    TriviaBefore = triviaSpaceBefore,
+                    TriviaAfter = triviaAfter,
+                    NewLine = processor.Line.NewLine,
+                });
+
+                if (!wasEmptyLine)
+                {
+                    processor.TriviaStart = processor.Start;
+                }
             }
+
             block.UpdateSpanEnd(processor.Line.End);
             return BlockState.Continue;
         }

--- a/src/Markdig/Parsers/ThematicBreakParser.cs
+++ b/src/Markdig/Parsers/ThematicBreakParser.cs
@@ -85,7 +85,7 @@ namespace Markdig.Parsers
             }
 
             // Push a new block
-            processor.NewBlocks.Push(new ThematicBreakBlock(this)
+            var thematicBreak = new ThematicBreakBlock(this)
             {
                 Column = processor.Column,
                 Span = new SourceSpan(startPosition, line.End),
@@ -94,10 +94,16 @@ namespace Markdig.Parsers
                 // TODO: should we separate whitespace before/after?
                 //BeforeWhitespace = beforeWhitespace,
                 //AfterWhitespace = processor.PopBeforeWhitespace(processor.CurrentLineStartPosition),
-                LinesBefore = processor.UseLinesBefore(),
                 Content = new StringSlice(line.Text, processor.TriviaStart, line.End, line.NewLine), //include whitespace for now
-                NewLine = processor.Line.NewLine,
-            });
+            };
+
+            if (processor.TrackTrivia)
+            {
+                thematicBreak.LinesBefore = processor.UseLinesBefore();
+                thematicBreak.NewLine = processor.Line.NewLine;
+            }
+
+            processor.NewBlocks.Push(thematicBreak);
             return BlockState.BreakDiscard;
         }
     }

--- a/src/Markdig/Roundtrip.md
+++ b/src/Markdig/Roundtrip.md
@@ -111,14 +111,14 @@ All trivia in a document should be attached to a node. The `Block` class defines
 /// <summary>
 /// Gets or sets the trivia right before this block.
 /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-/// <see cref="StringSlice.IsEmpty"/>.
+/// <see cref="StringSlice.Empty"/>.
 /// </summary>
 public StringSlice TriviaBefore { get; set; }
 
 /// <summary>
 /// Gets or sets trivia occurring after this block.
 /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-/// <see cref="StringSlice.IsEmpty"/>.
+/// <see cref="StringSlice.Empty"/>.
 /// </summary>
 public StringSlice TriviaAfter { get; set; }
 ```

--- a/src/Markdig/Syntax/CodeBlock.cs
+++ b/src/Markdig/Syntax/CodeBlock.cs
@@ -21,7 +21,8 @@ namespace Markdig.Syntax
             public StringSlice TriviaBefore { get; set; }
         }
 
-        public List<CodeBlockLine> CodeBlockLines { get; } = new ();
+        private List<CodeBlockLine>? _codeBlockLines;
+        public List<CodeBlockLine> CodeBlockLines => _codeBlockLines ??= new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CodeBlock"/> class.

--- a/src/Markdig/Syntax/FencedCodeBlock.cs
+++ b/src/Markdig/Syntax/FencedCodeBlock.cs
@@ -15,6 +15,9 @@ namespace Markdig.Syntax
     /// </remarks>
     public class FencedCodeBlock : CodeBlock, IFencedBlock
     {
+        private TriviaProperties? _trivia => TryGetDerivedTrivia<TriviaProperties>();
+        private TriviaProperties Trivia => GetOrSetDerivedTrivia<TriviaProperties>();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="FencedCodeBlock"/> class.
         /// </summary>
@@ -41,33 +44,44 @@ namespace Markdig.Syntax
         public int OpeningFencedCharCount { get; set; }
 
         /// <inheritdoc />
-        public StringSlice TriviaAfterFencedChar { get; set; }
+        public StringSlice TriviaAfterFencedChar { get => _trivia?.TriviaAfterFencedChar ?? StringSlice.Empty; set => Trivia.TriviaAfterFencedChar = value; }
 
         /// <inheritdoc />
         public string? Info { get; set; }
 
         /// <inheritdoc />
-        public StringSlice UnescapedInfo { get; set; }
+        public StringSlice UnescapedInfo { get => _trivia?.UnescapedInfo ?? StringSlice.Empty; set => Trivia.UnescapedInfo = value; }
 
         /// <inheritdoc />
-        public StringSlice TriviaAfterInfo { get; set; }
+        public StringSlice TriviaAfterInfo { get => _trivia?.TriviaAfterInfo ?? StringSlice.Empty; set => Trivia.TriviaAfterInfo = value; }
 
         /// <inheritdoc />
         public string? Arguments { get; set; }
 
         /// <inheritdoc />
-        public StringSlice UnescapedArguments { get; set; }
+        public StringSlice UnescapedArguments { get => _trivia?.UnescapedArguments ?? StringSlice.Empty; set => Trivia.UnescapedArguments = value; }
 
         /// <inheritdoc />
-        public StringSlice TriviaAfterArguments { get; set; }
+        public StringSlice TriviaAfterArguments { get => _trivia?.TriviaAfterArguments ?? StringSlice.Empty; set => Trivia.TriviaAfterArguments = value; }
 
         /// <inheritdoc />
-        public NewLine InfoNewLine { get; set; }
+        public NewLine InfoNewLine { get => _trivia?.InfoNewLine ?? NewLine.None; set => Trivia.InfoNewLine = value; }
 
         /// <inheritdoc />
-        public StringSlice TriviaBeforeClosingFence { get; set; }
+        public StringSlice TriviaBeforeClosingFence { get => _trivia?.TriviaBeforeClosingFence ?? StringSlice.Empty; set => Trivia.TriviaBeforeClosingFence = value; }
 
         /// <inheritdoc />
         public int ClosingFencedCharCount { get; set; }
+
+        private sealed class TriviaProperties
+        {
+            public StringSlice TriviaAfterFencedChar;
+            public StringSlice UnescapedInfo;
+            public StringSlice TriviaAfterInfo;
+            public StringSlice UnescapedArguments;
+            public StringSlice TriviaAfterArguments;
+            public NewLine InfoNewLine;
+            public StringSlice TriviaBeforeClosingFence;
+        }
     }
 }

--- a/src/Markdig/Syntax/HeadingBlock.cs
+++ b/src/Markdig/Syntax/HeadingBlock.cs
@@ -14,6 +14,9 @@ namespace Markdig.Syntax
     [DebuggerDisplay("{GetType().Name} Line: {Line}, {Lines} Level: {Level}")]
     public class HeadingBlock : LeafBlock
     {
+        private TriviaProperties? _trivia => TryGetDerivedTrivia<TriviaProperties>();
+        private TriviaProperties Trivia => GetOrSetDerivedTrivia<TriviaProperties>();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="HeadingBlock"/> class.
         /// </summary>
@@ -45,14 +48,21 @@ namespace Markdig.Syntax
 
         /// <summary>
         /// Gets or sets the newline of the first line when <see cref="IsSetext"/> is true.
+        /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled.
         /// </summary>
-        public NewLine SetextNewline { get; set; }
+        public NewLine SetextNewline { get => _trivia?.SetextNewline ?? NewLine.None; set => Trivia.SetextNewline = value; }
 
         /// <summary>
         /// Gets or sets the whitespace after the # character when <see cref="IsSetext"/> is false.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
-        public StringSlice TriviaAfterAtxHeaderChar { get; set; }
+        public StringSlice TriviaAfterAtxHeaderChar { get => _trivia?.TriviaAfterAtxHeaderChar ?? StringSlice.Empty; set => Trivia.TriviaAfterAtxHeaderChar = value; }
+
+        private sealed class TriviaProperties
+        {
+            public NewLine SetextNewline;
+            public StringSlice TriviaAfterAtxHeaderChar;
+        }
     }
 }

--- a/src/Markdig/Syntax/IBlock.cs
+++ b/src/Markdig/Syntax/IBlock.cs
@@ -61,13 +61,13 @@ namespace Markdig.Syntax
         /// <summary>
         /// Trivia occurring before this block
         /// </summary>
-        /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise <see cref="StringSlice.IsEmpty"/>.
+        /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise <see cref="StringSlice.Empty"/>.
         StringSlice TriviaBefore { get; set; }
 
         /// <summary>
         /// Trivia occurring after this block
         /// </summary>
-        /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise <see cref="StringSlice.IsEmpty"/>.
+        /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise <see cref="StringSlice.Empty"/>.
         StringSlice TriviaAfter { get; set; }
     }
 }

--- a/src/Markdig/Syntax/IFencedBlock.cs
+++ b/src/Markdig/Syntax/IFencedBlock.cs
@@ -3,7 +3,6 @@
 // See the license.txt file in the project root for more information.
 
 using Markdig.Helpers;
-using Markdig.Parsers;
 
 namespace Markdig.Syntax
 {
@@ -25,7 +24,7 @@ namespace Markdig.Syntax
         /// <summary>
         /// Gets or sets the trivia after the <see cref="FencedChar"/>.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
         StringSlice TriviaAfterFencedChar { get; set; }
 
@@ -38,14 +37,14 @@ namespace Markdig.Syntax
         /// <summary>
         /// Non-escaped <see cref="Info"/> exactly as in source markdown.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
         StringSlice UnescapedInfo { get; set; }
 
         /// <summary>
         /// Gets or sets the trivia after the <see cref="Info"/>.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
         StringSlice TriviaAfterInfo { get; set; }
 
@@ -58,28 +57,28 @@ namespace Markdig.Syntax
         /// <summary>
         /// Non-escaped <see cref="Arguments"/> exactly as in source markdown.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
         StringSlice UnescapedArguments { get; set; }
 
         /// <summary>
         /// Gets or sets the trivia after the <see cref="Arguments"/>.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
         StringSlice TriviaAfterArguments { get; set; }
 
         /// <summary>
         /// Newline of the line with the opening fenced chars.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="NewLine.None"/>.
         /// </summary>
         NewLine InfoNewLine { get; set; }
 
         /// <summary>
         /// Trivia before the closing fenced chars
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
         StringSlice TriviaBeforeClosingFence { get; set; }
 
@@ -92,7 +91,7 @@ namespace Markdig.Syntax
         /// Newline after the last line, which is always the line containing the closing fence chars.
         /// "Inherited" from <see cref="Block.NewLine"/>.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="NewLine.None"/>.
         /// </summary>
         NewLine NewLine { get; set; }
     }

--- a/src/Markdig/Syntax/Inlines/CodeInline.cs
+++ b/src/Markdig/Syntax/Inlines/CodeInline.cs
@@ -14,6 +14,9 @@ namespace Markdig.Syntax.Inlines
     [DebuggerDisplay("`{Content}`")]
     public class CodeInline : LeafInline
     {
+        private TriviaProperties? _trivia;
+        private TriviaProperties Trivia => _trivia ??= new();
+
         public CodeInline(string content)
         {
             Content = content;
@@ -37,16 +40,13 @@ namespace Markdig.Syntax.Inlines
         /// <summary>
         /// Gets or sets the content with trivia and whitespace.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
-        public StringSlice ContentWithTrivia { get; set; }
+        public StringSlice ContentWithTrivia { get => _trivia?.ContentWithTrivia ?? StringSlice.Empty; set => Trivia.ContentWithTrivia = value; }
 
-        /// <summary>
-        /// True if the first and last character of the content enclosed in a backtick `
-        /// is a space.
-        /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// false.
-        /// </summary>
-        public bool FirstAndLastWasSpace { get; set; }
+        private sealed class TriviaProperties
+        {
+            public StringSlice ContentWithTrivia;
+        }
     }
 }

--- a/src/Markdig/Syntax/Inlines/LinkDelimiterInline.cs
+++ b/src/Markdig/Syntax/Inlines/LinkDelimiterInline.cs
@@ -13,6 +13,9 @@ namespace Markdig.Syntax.Inlines
     /// <seealso cref="DelimiterInline" />
     public class LinkDelimiterInline : DelimiterInline
     {
+        private TriviaProperties? _trivia;
+        private TriviaProperties Trivia => _trivia ??= new();
+
         public LinkDelimiterInline(InlineParser parser) : base(parser)
         {
         }
@@ -35,13 +38,18 @@ namespace Markdig.Syntax.Inlines
         /// <summary>
         /// Gets or sets the <see cref="Label"/> with trivia.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
-        public StringSlice LabelWithTrivia { get; set; }
+        public StringSlice LabelWithTrivia { get => _trivia?.LabelWithTrivia ?? StringSlice.Empty; set => Trivia.LabelWithTrivia = value; }
 
         public override string ToLiteral()
         {
             return IsImage ? "![" : "[";
+        }
+
+        private sealed class TriviaProperties
+        {
+            public StringSlice LabelWithTrivia;
         }
     }
 }

--- a/src/Markdig/Syntax/Inlines/LinkInline.cs
+++ b/src/Markdig/Syntax/Inlines/LinkInline.cs
@@ -67,7 +67,7 @@ namespace Markdig.Syntax.Inlines
         /// <summary>
         /// Gets or sets the <see cref="Label"/> with trivia.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
         public StringSlice LabelWithTrivia { get => _trivia?.LabelWithTrivia ?? StringSlice.Empty; set => Trivia.LabelWithTrivia = value; }
 
@@ -98,7 +98,7 @@ namespace Markdig.Syntax.Inlines
         /// <summary>
         /// Gets or sets the trivia before the <see cref="Url"/>.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
         public StringSlice TriviaBeforeUrl { get => _trivia?.TriviaBeforeUrl ?? StringSlice.Empty; set => Trivia.TriviaBeforeUrl = value; }
 
@@ -123,14 +123,14 @@ namespace Markdig.Syntax.Inlines
         /// <summary>
         /// The <see cref="Url"/> but with trivia and unescaped characters
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
         public StringSlice UnescapedUrl { get => _trivia?.UnescapedUrl ?? StringSlice.Empty; set => Trivia.UnescapedUrl = value; }
 
         /// <summary>
         /// Any trivia after the <see cref="Url"/>.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
         public StringSlice TriviaAfterUrl { get => _trivia?.TriviaAfterUrl ?? StringSlice.Empty; set => Trivia.TriviaAfterUrl = value; }
 
@@ -160,14 +160,14 @@ namespace Markdig.Syntax.Inlines
         /// Gets or sets the <see cref="Title"/> exactly as parsed from the
         /// source document including unescaped characters
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
         public StringSlice UnescapedTitle { get => _trivia?.UnescapedTitle ?? StringSlice.Empty; set => Trivia.UnescapedTitle = value; }
 
         /// <summary>
         /// Gets or sets the trivia after the <see cref="Title"/>.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
         public StringSlice TriviaAfterTitle { get => _trivia?.TriviaAfterTitle ?? StringSlice.Empty; set => Trivia.TriviaAfterTitle = value; }
 

--- a/src/Markdig/Syntax/Inlines/LinkInline.cs
+++ b/src/Markdig/Syntax/Inlines/LinkInline.cs
@@ -7,12 +7,13 @@ using System.Diagnostics;
 
 namespace Markdig.Syntax.Inlines
 {
-    public enum LocalLabel
+    public enum LocalLabel : byte
     {
         Local, // [foo][bar]
         Empty, // [foo][]
         None, // [foo]
     }
+
     /// <summary>
     /// A Link inline (Section 6.5 CommonMark specs)
     /// </summary>
@@ -20,6 +21,9 @@ namespace Markdig.Syntax.Inlines
     [DebuggerDisplay("Url: {Url} Title: {Title} Image: {IsImage}")]
     public class LinkInline : ContainerInline
     {
+        private TriviaProperties? _trivia;
+        private TriviaProperties Trivia => _trivia ??= new();
+
         /// <summary>
         /// A delegate to use if it is setup on this instance to allow late binding 
         /// of a Url.
@@ -65,14 +69,14 @@ namespace Markdig.Syntax.Inlines
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
         /// <see cref="StringSlice.IsEmpty"/>.
         /// </summary>
-        public StringSlice LabelWithTrivia { get; set; }
+        public StringSlice LabelWithTrivia { get => _trivia?.LabelWithTrivia ?? StringSlice.Empty; set => Trivia.LabelWithTrivia = value; }
 
         /// <summary>
         /// Gets or sets the type of label parsed
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
         /// <see cref="LocalLabel.None"/>.
         /// </summary>
-        public LocalLabel LocalLabel { get; set; }
+        public LocalLabel LocalLabel { get => _trivia?.LocalLabel ?? LocalLabel.None; set => Trivia.LocalLabel = value; }
 
         /// <summary>
         /// Gets or sets the reference this link is attached to. May be null.
@@ -81,21 +85,22 @@ namespace Markdig.Syntax.Inlines
 
         /// <summary>
         /// Gets or sets the label as matched against the <see cref="LinkReferenceDefinition"/>.
+        /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled.
         /// </summary>
-        public string? LinkRefDefLabel { get; set; }
+        public string? LinkRefDefLabel { get => _trivia?.LinkRefDefLabel; set => Trivia.LinkRefDefLabel = value; }
 
         /// <summary>
         /// Gets or sets the <see cref="LinkRefDefLabel"/> with trivia as matched against
         /// the <see cref="LinkReferenceDefinition"/>
         /// </summary>
-        public StringSlice LinkRefDefLabelWithTrivia { get; set; }
+        public StringSlice LinkRefDefLabelWithTrivia { get => _trivia?.LinkRefDefLabelWithTrivia ?? StringSlice.Empty; set => Trivia.LinkRefDefLabelWithTrivia = value; }
 
         /// <summary>
         /// Gets or sets the trivia before the <see cref="Url"/>.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
         /// <see cref="StringSlice.IsEmpty"/>.
         /// </summary>
-        public StringSlice TriviaBeforeUrl { get; set; }
+        public StringSlice TriviaBeforeUrl { get => _trivia?.TriviaBeforeUrl ?? StringSlice.Empty; set => Trivia.TriviaBeforeUrl = value; }
 
         /// <summary>
         /// True if the <see cref="Url"/> in the source document is enclosed
@@ -103,7 +108,7 @@ namespace Markdig.Syntax.Inlines
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
         /// false.
         /// </summary>
-        public bool UrlHasPointyBrackets { get; set; }
+        public bool UrlHasPointyBrackets { get => _trivia?.UrlHasPointyBrackets ?? false; set => Trivia.UrlHasPointyBrackets = value; }
 
         /// <summary>
         /// Gets or sets the URL.
@@ -120,14 +125,14 @@ namespace Markdig.Syntax.Inlines
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
         /// <see cref="StringSlice.IsEmpty"/>.
         /// </summary>
-        public StringSlice UnescapedUrl { get; set; }
+        public StringSlice UnescapedUrl { get => _trivia?.UnescapedUrl ?? StringSlice.Empty; set => Trivia.UnescapedUrl = value; }
 
         /// <summary>
         /// Any trivia after the <see cref="Url"/>.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
         /// <see cref="StringSlice.IsEmpty"/>.
         /// </summary>
-        public StringSlice TriviaAfterUrl { get; set; }
+        public StringSlice TriviaAfterUrl { get => _trivia?.TriviaAfterUrl ?? StringSlice.Empty; set => Trivia.TriviaAfterUrl = value; }
 
         /// <summary>
         /// Gets or sets the GetDynamicUrl delegate. If this property is set, 
@@ -137,10 +142,9 @@ namespace Markdig.Syntax.Inlines
 
         /// <summary>
         /// Gets or sets the character used to enclose the <see cref="Title"/>.
-        /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled.
         /// </summary>
-        public char TitleEnclosingCharacter { get; set; }
+        public char TitleEnclosingCharacter { get => _trivia?.TitleEnclosingCharacter ?? default; set => Trivia.TitleEnclosingCharacter = value; }
 
         /// <summary>
         /// Gets or sets the title.
@@ -158,14 +162,14 @@ namespace Markdig.Syntax.Inlines
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
         /// <see cref="StringSlice.IsEmpty"/>.
         /// </summary>
-        public StringSlice UnescapedTitle { get; set; }
+        public StringSlice UnescapedTitle { get => _trivia?.UnescapedTitle ?? StringSlice.Empty; set => Trivia.UnescapedTitle = value; }
 
         /// <summary>
         /// Gets or sets the trivia after the <see cref="Title"/>.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
         /// <see cref="StringSlice.IsEmpty"/>.
         /// </summary>
-        public StringSlice TriviaAfterTitle { get; set; }
+        public StringSlice TriviaAfterTitle { get => _trivia?.TriviaAfterTitle ?? StringSlice.Empty; set => Trivia.TriviaAfterTitle = value; }
 
         /// <summary>
         /// Gets or sets a boolean indicating if this link is a shortcut link to a <see cref="LinkReferenceDefinition"/>
@@ -176,5 +180,20 @@ namespace Markdig.Syntax.Inlines
         /// Gets or sets a boolean indicating whether the inline link was parsed using markdown syntax or was automatic recognized.
         /// </summary>
         public bool IsAutoLink { get; set; }
+
+        private sealed class TriviaProperties
+        {
+            public StringSlice LabelWithTrivia;
+            public LocalLabel LocalLabel;
+            public string? LinkRefDefLabel;
+            public StringSlice LinkRefDefLabelWithTrivia;
+            public StringSlice TriviaBeforeUrl;
+            public bool UrlHasPointyBrackets;
+            public StringSlice UnescapedUrl;
+            public StringSlice TriviaAfterUrl;
+            public char TitleEnclosingCharacter;
+            public StringSlice UnescapedTitle;
+            public StringSlice TriviaAfterTitle;
+        }
     }
 }

--- a/src/Markdig/Syntax/LinkReferenceDefinition.cs
+++ b/src/Markdig/Syntax/LinkReferenceDefinition.cs
@@ -16,6 +16,9 @@ namespace Markdig.Syntax
     /// <seealso cref="LeafBlock" />
     public class LinkReferenceDefinition : LeafBlock
     {
+        private TriviaProperties? _trivia;
+        private TriviaProperties Trivia => _trivia ??= new();
+
         /// <summary>
         /// Creates an inline link for the specified <see cref="LinkReferenceDefinition"/>.
         /// </summary>
@@ -62,14 +65,14 @@ namespace Markdig.Syntax
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
         /// <see cref="StringSlice.IsEmpty"/>.
         /// </summary>
-        public StringSlice LabelWithTrivia { get; set; }
+        public StringSlice LabelWithTrivia { get => _trivia?.LabelWithTrivia ?? StringSlice.Empty; set => Trivia.LabelWithTrivia = value; }
 
         /// <summary>
         /// Whitespace before the <see cref="Url"/>.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
         /// <see cref="StringSlice.IsEmpty"/>.
         /// </summary>
-        public StringSlice TriviaBeforeUrl { get; set; }
+        public StringSlice TriviaBeforeUrl { get => _trivia?.TriviaBeforeUrl ?? StringSlice.Empty; set => Trivia.TriviaBeforeUrl = value; }
 
         /// <summary>
         /// Gets or sets the URL.
@@ -86,21 +89,21 @@ namespace Markdig.Syntax
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
         /// <see cref="StringSlice.IsEmpty"/>.
         /// </summary>
-        public StringSlice UnescapedUrl { get; set; }
+        public StringSlice UnescapedUrl { get => _trivia?.UnescapedUrl ?? StringSlice.Empty; set => Trivia.UnescapedUrl = value; }
 
         /// <summary>
         /// True when the <see cref="Url"/> is enclosed in point brackets in the source document.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
         /// false.
         /// </summary>
-        public bool UrlHasPointyBrackets { get; set; }
+        public bool UrlHasPointyBrackets { get => _trivia?.UrlHasPointyBrackets ?? false; set => Trivia.UrlHasPointyBrackets = value; }
 
         /// <summary>
         /// gets or sets the whitespace before a <see cref="Title"/>.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
         /// <see cref="StringSlice.IsEmpty"/>.
         /// </summary>
-        public StringSlice TriviaBeforeTitle { get; set; }
+        public StringSlice TriviaBeforeTitle { get => _trivia?.TriviaBeforeTitle ?? StringSlice.Empty; set => Trivia.TriviaBeforeTitle = value; }
 
         /// <summary>
         /// Gets or sets the title.
@@ -117,13 +120,13 @@ namespace Markdig.Syntax
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
         /// <see cref="StringSlice.IsEmpty"/>.
         /// </summary>
-        public StringSlice UnescapedTitle { get; set; }
+        public StringSlice UnescapedTitle { get => _trivia?.UnescapedTitle ?? StringSlice.Empty; set => Trivia.UnescapedTitle = value; }
 
         /// <summary>
         /// Gets or sets the character the <see cref="Title"/> is enclosed in.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise \0.
         /// </summary>
-        public char TitleEnclosingCharacter { get; set; }
+        public char TitleEnclosingCharacter { get => _trivia?.TitleEnclosingCharacter ?? default; set => Trivia.TitleEnclosingCharacter = value; }
 
         /// <summary>
         /// Gets or sets the create link inline callback for this instance.
@@ -226,6 +229,17 @@ namespace Markdig.Syntax
                 NewLine = newLine,
             };
             return true;
+        }
+
+        private sealed class TriviaProperties
+        {
+            public StringSlice LabelWithTrivia;
+            public StringSlice TriviaBeforeUrl;
+            public StringSlice UnescapedUrl;
+            public bool UrlHasPointyBrackets;
+            public StringSlice TriviaBeforeTitle;
+            public StringSlice UnescapedTitle;
+            public char TitleEnclosingCharacter;
         }
     }
 }

--- a/src/Markdig/Syntax/LinkReferenceDefinition.cs
+++ b/src/Markdig/Syntax/LinkReferenceDefinition.cs
@@ -16,8 +16,8 @@ namespace Markdig.Syntax
     /// <seealso cref="LeafBlock" />
     public class LinkReferenceDefinition : LeafBlock
     {
-        private TriviaProperties? _trivia;
-        private TriviaProperties Trivia => _trivia ??= new();
+        private TriviaProperties? _trivia => TryGetDerivedTrivia<TriviaProperties>();
+        private TriviaProperties Trivia => GetOrSetDerivedTrivia<TriviaProperties>();
 
         /// <summary>
         /// Creates an inline link for the specified <see cref="LinkReferenceDefinition"/>.

--- a/src/Markdig/Syntax/LinkReferenceDefinition.cs
+++ b/src/Markdig/Syntax/LinkReferenceDefinition.cs
@@ -63,14 +63,14 @@ namespace Markdig.Syntax
         /// <summary>
         /// Non-normalized Label (includes trivia)
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
         public StringSlice LabelWithTrivia { get => _trivia?.LabelWithTrivia ?? StringSlice.Empty; set => Trivia.LabelWithTrivia = value; }
 
         /// <summary>
         /// Whitespace before the <see cref="Url"/>.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
         public StringSlice TriviaBeforeUrl { get => _trivia?.TriviaBeforeUrl ?? StringSlice.Empty; set => Trivia.TriviaBeforeUrl = value; }
 
@@ -87,7 +87,7 @@ namespace Markdig.Syntax
         /// <summary>
         /// Non-normalized <see cref="Url"/>.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
         public StringSlice UnescapedUrl { get => _trivia?.UnescapedUrl ?? StringSlice.Empty; set => Trivia.UnescapedUrl = value; }
 
@@ -101,7 +101,7 @@ namespace Markdig.Syntax
         /// <summary>
         /// gets or sets the whitespace before a <see cref="Title"/>.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
         public StringSlice TriviaBeforeTitle { get => _trivia?.TriviaBeforeTitle ?? StringSlice.Empty; set => Trivia.TriviaBeforeTitle = value; }
 
@@ -118,7 +118,7 @@ namespace Markdig.Syntax
         /// <summary>
         /// Non-normalized <see cref="Title"/>.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
         public StringSlice UnescapedTitle { get => _trivia?.UnescapedTitle ?? StringSlice.Empty; set => Trivia.UnescapedTitle = value; }
 

--- a/src/Markdig/Syntax/ListItemBlock.cs
+++ b/src/Markdig/Syntax/ListItemBlock.cs
@@ -13,6 +13,9 @@ namespace Markdig.Syntax
     /// <seealso cref="ContainerBlock" />
     public class ListItemBlock : ContainerBlock
     {
+        private TriviaProperties? _trivia => TryGetDerivedTrivia<TriviaProperties>();
+        private TriviaProperties Trivia => GetOrSetDerivedTrivia<TriviaProperties>();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ListItemBlock"/> class.
         /// </summary>
@@ -31,8 +34,13 @@ namespace Markdig.Syntax
         /// <summary>
         /// Gets or sets the bullet as parsed in the source document.
         /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// <see cref="StringSlice.Empty"/>.
         /// </summary>
-        public StringSlice SourceBullet { get; set; }
+        public StringSlice SourceBullet { get => _trivia?.SourceBullet ?? StringSlice.Empty; set => Trivia.SourceBullet = value; }
+
+        private sealed class TriviaProperties
+        {
+            public StringSlice SourceBullet;
+        }
     }
 }

--- a/src/Markdig/Syntax/QuoteBlock.cs
+++ b/src/Markdig/Syntax/QuoteBlock.cs
@@ -14,6 +14,8 @@ namespace Markdig.Syntax
     /// <seealso cref="ContainerBlock" />
     public class QuoteBlock : ContainerBlock
     {
+        private List<QuoteBlockLine> Trivia => GetOrSetDerivedTrivia<List<QuoteBlockLine>>();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="QuoteBlock"/> class.
         /// </summary>
@@ -24,10 +26,9 @@ namespace Markdig.Syntax
 
         /// <summary>
         /// Gets or sets the trivia per line of this QuoteBlock.
-        /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="StringSlice.IsEmpty"/>.
+        /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise null.
         /// </summary>
-        public List<QuoteBlockLine> QuoteLines { get; } = new ();
+        public List<QuoteBlockLine> QuoteLines => Trivia;
 
         /// <summary>
         /// Gets or sets the quote character (usually `&gt;`)
@@ -37,30 +38,23 @@ namespace Markdig.Syntax
 
     /// <summary>
     /// Represents trivia per line part of a QuoteBlock.
-    /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-    /// <see cref="QuoteBlock.QuoteLines"/> is empty.
+    /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled.
     /// </summary>
     public class QuoteBlockLine
     {
         /// <summary>
         /// Gets or sets trivia occuring before the first quote character.
-        /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="QuoteBlock.QuoteLines"/> is empty.
         /// </summary>
         public StringSlice TriviaBefore { get; set; }
 
         /// <summary>
         /// True when this QuoteBlock line has a quote character. False when
         /// this line is a "lazy line".
-        /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="QuoteBlock.QuoteLines"/> is empty.
         /// </summary>
         public bool QuoteChar { get; set; }
 
         /// <summary>
         /// True if a space is parsed right after the quote character.
-        /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="QuoteBlock.QuoteLines"/> is empty.
         /// </summary>
         public bool HasSpaceAfterQuoteChar { get; set; }
 
@@ -68,15 +62,11 @@ namespace Markdig.Syntax
         /// Gets or sets the trivia after the the space after the quote character.
         /// The first space is assigned to <see cref="HasSpaceAfterQuoteChar"/>, subsequent
         /// trivia is assigned to this property.
-        /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="QuoteBlock.QuoteLines"/> is empty.
         /// </summary>
         public StringSlice TriviaAfter { get; set; }
 
         /// <summary>
         /// Gets or sets the newline of this QuoeBlockLine.
-        /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise
-        /// <see cref="QuoteBlock.QuoteLines"/> is empty.
         /// </summary>
         public NewLine NewLine { get; set; }
     }


### PR DESCRIPTION
A few changes mainly around reducing the overhead of the `TrackTrivia` impl even when it isn't requested:
- `Span.IndexOfAny('\r', '\n')` in `LineReader`
- Moving all trivia properties to lazy-allocated objects to reduce the size of `Syntax` objects.
- Avoiding work that's only relevant for trivia when it's not needed

I was playing around with two markdown documents for these:
- The Markdig readme
- A random doc [article](https://github.com/microsoft/reverse-proxy/blob/main/docs/docfx/articles/distributed-tracing.md)

Before
|         Method |      Mean |    Error |   StdDev |   Gen 0 |   Gen 1 | Allocated |
|--------------- |----------:|---------:|---------:|--------:|--------:|----------:|
|  MarkdigReadme | 315.18 us | 0.695 us | 1.019 us | 36.1328 | 12.2070 |    169 KB |
| TracingArticle |  43.94 us | 0.080 us | 0.115 us |  5.6763 |  0.3052 |     23 KB |

After
|         Method |      Mean |    Error |   StdDev |   Gen 0 |   Gen 1 | Allocated |
|--------------- |----------:|---------:|---------:|--------:|--------:|----------:|
|  MarkdigReadme | 305.87 us | 3.347 us | 5.010 us | 32.7148 | 10.7422 |    136 KB |
| TracingArticle |  41.33 us | 0.136 us | 0.200 us |  4.4556 |       - |     18 KB |