### PR TITLE
Some CPU improvements

### DIFF
--- a/src/Markdig.Tests/TestFencedCodeBlocks.cs
+++ b/src/Markdig.Tests/TestFencedCodeBlocks.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using Markdig.Syntax;
+using NUnit.Framework;
+
+namespace Markdig.Tests
+{
+    public class TestFencedCodeBlocks
+    {
+        [Test]
+        [TestCase("c#", "c#", "")]
+        [TestCase("C#", "C#", "")]
+        [TestCase(" c#", "c#", "")]
+        [TestCase(" c# ", "c#", "")]
+        [TestCase(" \tc# ", "c#", "")]
+        [TestCase("\t c# \t", "c#", "")]
+        [TestCase(" c# ", "c#", "")]
+        [TestCase(" c# foo", "c#", "foo")]
+        [TestCase(" c# \t  fOo \t", "c#", "fOo")]
+        [TestCase("in\\%fo arg\\%ument", "in%fo", "arg%ument")]
+        [TestCase("info&#9; arg&acute;ument", "info\t", "arg\u00B4ument")]
+        public void TestInfoAndArguments(string infoString, string expectedInfo, string expectedArguments)
+        {
+            Test('`');
+            Test('~');
+
+            void Test(char fencedChar)
+            {
+                const string Contents = "Foo\nBar\n";
+
+                string fence = new string(fencedChar, 3);
+                string markdownText = $"{fence}{infoString}\n{Contents}\n{fence}\n";
+
+                MarkdownDocument document = Markdown.Parse(markdownText);
+
+                FencedCodeBlock codeBlock = document.Descendants<FencedCodeBlock>().Single();
+
+                Assert.AreEqual(fencedChar, codeBlock.FencedChar);
+                Assert.AreEqual(3, codeBlock.OpeningFencedCharCount);
+                Assert.AreEqual(3, codeBlock.ClosingFencedCharCount);
+                Assert.AreEqual(expectedInfo, codeBlock.Info);
+                Assert.AreEqual(expectedArguments, codeBlock.Arguments);
+                Assert.AreEqual(Contents, codeBlock.Lines.ToString());
+            }
+        }
+    }
+}

--- a/src/Markdig.Tests/TestTransformedStringCache.cs
+++ b/src/Markdig.Tests/TestTransformedStringCache.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Linq;
+using Markdig.Helpers;
+using NUnit.Framework;
+
+namespace Markdig.Tests
+{
+    public class TestTransformedStringCache
+    {
+        [Test]
+        public void GetRunsTransformationCallback()
+        {
+            var cache = new TransformedStringCache(static s => "callback-" + s);
+
+            Assert.AreEqual("callback-foo", cache.Get("foo"));
+            Assert.AreEqual("callback-bar", cache.Get("bar"));
+            Assert.AreEqual("callback-baz", cache.Get("baz"));
+        }
+
+        [Test]
+        public void CachesTransformedInstance()
+        {
+            var cache = new TransformedStringCache(static s => "callback-" + s);
+
+            string transformedBar = cache.Get("bar");
+            Assert.AreSame(transformedBar, cache.Get("bar"));
+
+            string transformedFoo = cache.Get("foo".AsSpan());
+            Assert.AreSame(transformedFoo, cache.Get("foo"));
+
+            Assert.AreSame(cache.Get("baz"), cache.Get("baz".AsSpan()));
+
+            Assert.AreSame(transformedBar, cache.Get("bar"));
+            Assert.AreSame(transformedFoo, cache.Get("foo"));
+            Assert.AreSame(transformedBar, cache.Get("bar".AsSpan()));
+            Assert.AreSame(transformedFoo, cache.Get("foo".AsSpan()));
+        }
+
+        [Test]
+        public void DoesNotCacheEmptyInputs()
+        {
+            var cache = new TransformedStringCache(static s => new string('a', 4));
+
+            string cached = cache.Get("");
+            string cached2 = cache.Get("");
+            string cached3 = cache.Get(ReadOnlySpan<char>.Empty);
+
+            Assert.AreEqual("aaaa", cached);
+            Assert.AreEqual(cached, cached2);
+            Assert.AreEqual(cached, cached3);
+
+            Assert.AreNotSame(cached, cached2);
+            Assert.AreNotSame(cached, cached3);
+            Assert.AreNotSame(cached2, cached3);
+        }
+
+        [Test]
+        [TestCase(TransformedStringCache.InputLengthLimit, true)]
+        [TestCase(TransformedStringCache.InputLengthLimit + 1, false)]
+        public void DoesNotCacheLongInputs(int length, bool shouldBeCached)
+        {
+            var cache = new TransformedStringCache(static s => "callback-" + s);
+
+            string input = new string('a', length);
+
+            string cached = cache.Get(input);
+            string cached2 = cache.Get(input);
+
+            Assert.AreEqual("callback-" + input, cached);
+            Assert.AreEqual(cached, cached2);
+
+            if (shouldBeCached)
+            {
+                Assert.AreSame(cached, cached2);
+            }
+            else
+            {
+                Assert.AreNotSame(cached, cached2);
+            }
+        }
+
+        [Test]
+        public void CachesAtMostNEntriesPerCharacter()
+        {
+            var cache = new TransformedStringCache(static s => "callback-" + s);
+
+            int limit = TransformedStringCache.MaxEntriesPerCharacter;
+
+            string[] a = Enumerable.Range(1, limit + 1).Select(i => $"a{i}").ToArray();
+            string[] cachedAs = a.Select(a => cache.Get(a)).ToArray();
+
+            for (int i = 0; i < limit; i++)
+            {
+                Assert.AreSame(cachedAs[i], cache.Get(a[i]));
+            }
+
+            Assert.AreNotSame(cachedAs[limit], cache.Get(a[limit]));
+
+            Assert.AreSame(cache.Get("b1"), cache.Get("b1"));
+        }
+    }
+}

--- a/src/Markdig/Extensions/JiraLinks/JiraLinkInlineParser.cs
+++ b/src/Markdig/Extensions/JiraLinks/JiraLinkInlineParser.cs
@@ -95,13 +95,19 @@ namespace Markdig.Extensions.JiraLinks
             jiraLink.Span.End = jiraLink.Span.Start + (endIssue - startKey);
 
             // Builds the Url
-            var builder = StringBuilderCache.Local();
-            builder.Append(_baseUrl).Append('/').Append(jiraLink.ProjectKey).Append('-').Append(jiraLink.Issue);
-            jiraLink.Url = builder.ToString();
+            var builder = new ValueStringBuilder(stackalloc char[ValueStringBuilder.StackallocThreshold]);
+            builder.Append(_baseUrl);
+            builder.Append('/');
+            builder.Append(jiraLink.ProjectKey.AsSpan());
+            builder.Append('-');
+            builder.Append(jiraLink.Issue.AsSpan());
+            jiraLink.Url = builder.AsSpan().ToString();
 
             // Builds the Label
             builder.Length = 0;
-            builder.Append(jiraLink.ProjectKey).Append('-').Append(jiraLink.Issue);
+            builder.Append(jiraLink.ProjectKey.AsSpan());
+            builder.Append('-');
+            builder.Append(jiraLink.Issue.AsSpan());
             jiraLink.AppendChild(new LiteralInline(builder.ToString()));
 
             if (_options.OpenInNewWindow)

--- a/src/Markdig/Extensions/JiraLinks/JiraLinkOptions.cs
+++ b/src/Markdig/Extensions/JiraLinks/JiraLinkOptions.cs
@@ -2,7 +2,8 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
-using System.Text;
+using Markdig.Helpers;
+using System;
 
 namespace Markdig.Extensions.JiraLinks
 {
@@ -38,20 +39,10 @@ namespace Markdig.Extensions.JiraLinks
         /// </summary>
         public virtual string GetUrl()
         {
-            var url = new StringBuilder();
-            var baseUrl = BaseUrl;
-            if (baseUrl != null)
-            {
-                url.Append(baseUrl.TrimEnd('/'));
-            }
-
-            url.Append("/");
-
-            if (BasePath != null)
-            {
-                url.Append(BasePath.Trim('/'));
-            }
-
+            var url = new ValueStringBuilder(stackalloc char[ValueStringBuilder.StackallocThreshold]);
+            url.Append(BaseUrl.AsSpan().TrimEnd('/'));
+            url.Append('/');
+            url.Append(BasePath.AsSpan().Trim('/'));
             return url.ToString();
         }
     }

--- a/src/Markdig/Extensions/Tables/PipeTableParser.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableParser.cs
@@ -43,7 +43,7 @@ namespace Markdig.Extensions.Tables
         public override bool Match(InlineProcessor processor, ref StringSlice slice)
         {
             // Only working on Paragraph block
-            if (!(processor.Block is ParagraphBlock))
+            if (!processor.Block!.IsParagraphBlock)
             {
                 return false;
             }

--- a/src/Markdig/Helpers/EntityHelper.cs
+++ b/src/Markdig/Helpers/EntityHelper.cs
@@ -33,7 +33,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Markdig.Helpers
 {
@@ -81,7 +80,7 @@ namespace Markdig.Helpers
             });
         }
 
-        public static void DecodeEntity(int utf32, StringBuilder sb)
+        internal static void DecodeEntity(int utf32, ref ValueStringBuilder sb)
         {
             if (!CharHelper.IsInInclusiveRange(utf32, 1, 1114111) || CharHelper.IsInInclusiveRange(utf32, 55296, 57343))
             {
@@ -99,7 +98,7 @@ namespace Markdig.Helpers
             }
         }
 
-#region [ EntityMap ]
+        #region [ EntityMap ]
         /// <summary>
         /// Source: http://www.w3.org/html/wg/drafts/html/master/syntax.html#named-character-references
         /// </summary>

--- a/src/Markdig/Helpers/HtmlHelper.cs
+++ b/src/Markdig/Helpers/HtmlHelper.cs
@@ -434,7 +434,7 @@ namespace Markdig.Helpers
             // remove backslashes before punctuation chars:
             int searchPos = 0;
             int lastPos = 0;
-            char c;
+            char c = '\0';
             char[] search = removeBackSlash ? SearchBackAndAmp : SearchAmp;
             var sb = new ValueStringBuilder(stackalloc char[ValueStringBuilder.StackallocThreshold]);
 
@@ -486,7 +486,7 @@ namespace Markdig.Helpers
                 }
             }
 
-            if (lastPos == 0)
+            if (c == 0)
             {
                 sb.Dispose();
                 return text;

--- a/src/Markdig/Helpers/StringBuilderExtensions.cs
+++ b/src/Markdig/Helpers/StringBuilderExtensions.cs
@@ -20,12 +20,5 @@ namespace Markdig.Helpers
         {
             return builder.Append(slice.Text, slice.Start, slice.Length);
         }
-
-        internal static string GetStringAndReset(this StringBuilder builder)
-        {
-            string text = builder.ToString();
-            builder.Length = 0;
-            return text;
-        }
     }
 }

--- a/src/Markdig/Helpers/StringLineGroup.cs
+++ b/src/Markdig/Helpers/StringLineGroup.cs
@@ -139,7 +139,7 @@ namespace Markdig.Helpers
             }
 
             // Else use a builder
-            var builder = StringBuilderCache.Local();
+            var builder = new ValueStringBuilder(stackalloc char[ValueStringBuilder.StackallocThreshold]);
             int previousStartOfLine = 0;
             var newLine = NewLine.None;
             for (int i = 0; i < Count; i++)
@@ -152,13 +152,13 @@ namespace Markdig.Helpers
                 ref StringLine line = ref Lines[i];
                 if (!line.Slice.IsEmpty)
                 {
-                    builder.Append(line.Slice.Text, line.Slice.Start, line.Slice.Length);
+                    builder.Append(line.Slice.AsSpan());
                 }
                 newLine = line.NewLine;
 
                 lineOffsets?.Add(new LineOffset(line.Position, line.Column, line.Slice.Start - line.Position, previousStartOfLine, builder.Length));
             }
-            return new StringSlice(builder.GetStringAndReset());
+            return new StringSlice(builder.ToString());
         }
 
         /// <summary>

--- a/src/Markdig/Helpers/StringLineGroup.cs
+++ b/src/Markdig/Helpers/StringLineGroup.cs
@@ -255,7 +255,6 @@ namespace Markdig.Helpers
             public StringLineGroup Remaining()
             {
                 StringLineGroup lines = _lines;
-
                 if (IsEmpty)
                 {
                     lines.Clear();

--- a/src/Markdig/Helpers/StringLineGroup.cs
+++ b/src/Markdig/Helpers/StringLineGroup.cs
@@ -85,6 +85,14 @@ namespace Markdig.Helpers
             Count--;
         }
 
+        internal void RemoveStartRange(int toRemove)
+        {
+            int remaining = Count - toRemove;
+            Count = remaining;
+            Array.Copy(Lines, toRemove, Lines, 0, remaining);
+            Array.Clear(Lines, remaining, toRemove);
+        }
+
         /// <summary>
         /// Adds the specified line to this instance.
         /// </summary>
@@ -213,21 +221,24 @@ namespace Markdig.Helpers
         public struct Iterator : ICharIterator
         {
             private readonly StringLineGroup _lines;
+            private StringSlice _currentSlice;
             private int _offset;
 
-            public Iterator(StringLineGroup lines)
+            public Iterator(StringLineGroup stringLineGroup)
             {
-                this._lines = lines;
+                _lines = stringLineGroup;
                 Start = -1;
                 _offset = -1;
                 SliceIndex = 0;
                 CurrentChar = '\0';
                 End = -1;
-                for (int i = 0; i < lines.Count; i++)
+                StringLine[] lines = stringLineGroup.Lines;
+                for (int i = 0; i < stringLineGroup.Count && i < lines.Length; i++)
                 {
-                    ref StringLine line = ref lines.Lines[i];
-                    End += line.Slice.Length + line.NewLine.Length(); // Add chars
+                    ref StringSlice slice = ref lines[i].Slice;
+                    End += slice.Length + slice.NewLine.Length(); // Add chars
                 }
+                _currentSlice = _lines.Lines[0].Slice;
                 SkipChar();
             }
 
@@ -243,17 +254,15 @@ namespace Markdig.Helpers
 
             public StringLineGroup Remaining()
             {
-                var lines = _lines;
+                StringLineGroup lines = _lines;
+
                 if (IsEmpty)
                 {
                     lines.Clear();
                 }
                 else
                 {
-                    for (int i = SliceIndex - 1; i >= 0; i--)
-                    {
-                        lines.RemoveAt(i);
-                    }
+                    lines.RemoveStartRange(SliceIndex);
 
                     if (lines.Count > 0 && _offset > 0)
                     {
@@ -266,59 +275,85 @@ namespace Markdig.Helpers
                 return lines;
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public char NextChar()
             {
                 Start++;
                 if (Start <= End)
                 {
-                    var slice = _lines.Lines[SliceIndex].Slice;
+                    ref StringSlice slice = ref _currentSlice;
                     _offset++;
-                    if (_offset < slice.Length)
+
+                    int index = slice.Start + _offset;
+                    string text = slice.Text;
+                    if (index <= slice.End && (uint)index < (uint)text.Length)
                     {
-                        CurrentChar = slice[slice.Start + _offset];
+                        char c = text[index];
+                        CurrentChar = c;
+                        return c;
                     }
                     else
                     {
-                        var newLine = slice.NewLine;
-                        if (_offset == slice.Length)
-                        {
-                            if (newLine == NewLine.LineFeed)
-                            {
-                                CurrentChar = '\n';
-                                SliceIndex++;
-                                _offset = -1;
-                            }
-                            else if (newLine == NewLine.CarriageReturn)
-                            {
-                                CurrentChar = '\r';
-                                SliceIndex++;
-                                _offset = -1;
-                            }
-                            else if (newLine == NewLine.CarriageReturnLineFeed)
-                            {
-                                CurrentChar = '\r';
-                            }
-                        }
-                        else if (_offset - 1 == slice.Length)
-                        {
-                            if (newLine == NewLine.CarriageReturnLineFeed)
-                            {
-                                CurrentChar = '\n';
-                                SliceIndex++;
-                                _offset = -1;
-                            }
-                        }
+                        return NextCharNewLine();
                     }
                 }
                 else
                 {
-                    CurrentChar = '\0';
-                    Start = End + 1;
-                    SliceIndex = _lines.Count;
+                    return NextCharEndOfEnumerator();
                 }
+            }
+
+            private char NextCharNewLine()
+            {
+                int sliceLength = _currentSlice.Length;
+                NewLine newLine = _currentSlice.NewLine;
+
+                if (_offset == sliceLength)
+                {
+                    if (newLine == NewLine.LineFeed)
+                    {
+                        CurrentChar = '\n';
+                        goto MoveToNewLine;
+                    }
+                    else if (newLine == NewLine.CarriageReturn)
+                    {
+                        CurrentChar = '\r';
+                        goto MoveToNewLine;
+                    }
+                    else if (newLine == NewLine.CarriageReturnLineFeed)
+                    {
+                        CurrentChar = '\r';
+                    }
+                }
+                else if (_offset - 1 == sliceLength)
+                {
+                    if (newLine == NewLine.CarriageReturnLineFeed)
+                    {
+                        CurrentChar = '\n';
+                        goto MoveToNewLine;
+                    }
+                }
+
+                goto Return;
+
+            MoveToNewLine:
+                SliceIndex++;
+                _offset = -1;
+                _currentSlice = _lines.Lines[SliceIndex];
+
+            Return:
                 return CurrentChar;
             }
 
+            private char NextCharEndOfEnumerator()
+            {
+                CurrentChar = '\0';
+                Start = End + 1;
+                SliceIndex = _lines.Count;
+                return '\0';
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void SkipChar() => NextChar();
 
             public readonly char PeekChar() => PeekChar(1);
@@ -335,16 +370,17 @@ namespace Markdig.Helpers
                 offset += _offset;
 
                 int sliceIndex = SliceIndex;
-                ref StringLine line = ref _lines.Lines[sliceIndex];
-                ref StringSlice slice = ref line.Slice;
-                if (!(line.NewLine == NewLine.CarriageReturnLineFeed && offset == slice.Length + 1))
+                ref StringSlice slice = ref _lines.Lines[sliceIndex].Slice;
+                NewLine newLine = slice.NewLine;
+
+                if (!(newLine == NewLine.CarriageReturnLineFeed && offset == slice.Length + 1))
                 {
                     while (offset > slice.Length)
                     {
                         // We are not peeking at the same line
                         offset -= slice.Length + 1; // + 1 for new line
 
-                        Debug.Assert(sliceIndex + 1 < _lines.Lines.Length, "'Start + offset > End' check above should prevent us from indexing out of range");
+                        Debug.Assert(sliceIndex + 1 < _lines.Count, "'Start + offset > End' check above should prevent us from indexing out of range");
                         slice = ref _lines.Lines[++sliceIndex].Slice;
                     }
                 }
@@ -358,15 +394,15 @@ namespace Markdig.Helpers
 
                 if (offset == slice.Length)
                 {
-                    if (line.NewLine == NewLine.LineFeed)
+                    if (newLine == NewLine.LineFeed)
                     {
                         return '\n';
                     }
-                    if (line.NewLine == NewLine.CarriageReturn)
+                    if (newLine == NewLine.CarriageReturn)
                     {
                         return '\r';
                     }
-                    if (line.NewLine == NewLine.CarriageReturnLineFeed)
+                    if (newLine == NewLine.CarriageReturnLineFeed)
                     {
                         return '\r'; // /r of /r/n (first character)
                     }

--- a/src/Markdig/Helpers/StringSlice.cs
+++ b/src/Markdig/Helpers/StringSlice.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Markdig.Helpers
 {
@@ -460,6 +461,24 @@ namespace Markdig.Helpers
                 return string.Empty;
             }
             return text.Substring(start, length);
+        }
+
+        public readonly ReadOnlySpan<char> AsSpan()
+        {
+            string text = Text;
+            int start = Start;
+            int length = End - start + 1;
+
+            if (text is null || (ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)text.Length)
+            {
+                return default;
+            }
+
+#if NETCOREAPP3_1_OR_GREATER
+            return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.Add(ref Unsafe.AsRef(text.GetPinnableReference()), start), length);
+#else
+            return text.AsSpan(start, length);
+#endif
         }
 
         /// <summary>

--- a/src/Markdig/Helpers/StringSlice.cs
+++ b/src/Markdig/Helpers/StringSlice.cs
@@ -463,6 +463,7 @@ namespace Markdig.Helpers
             return text.Substring(start, length);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly ReadOnlySpan<char> AsSpan()
         {
             string text = Text;

--- a/src/Markdig/Helpers/TransformedStringCache.cs
+++ b/src/Markdig/Helpers/TransformedStringCache.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Threading;
+
+namespace Markdig.Helpers
+{
+    internal sealed class TransformedStringCache
+    {
+        internal const int InputLengthLimit = 20; // Avoid caching unreasonably long strings
+        internal const int MaxEntriesPerCharacter = 8; // Avoid growing too much
+
+        private readonly EntryGroup[] _groups; // One per ASCII character
+        private readonly Func<string, string> _transformation;
+
+        public TransformedStringCache(Func<string, string> transformation)
+        {
+            _transformation = transformation ?? throw new ArgumentNullException(nameof(transformation));
+            _groups = new EntryGroup[128];
+        }
+
+        public string Get(ReadOnlySpan<char> inputSpan)
+        {
+            if ((uint)(inputSpan.Length - 1) < InputLengthLimit) // Length: [1, LengthLimit]
+            {
+                int firstCharacter = inputSpan[0];
+                EntryGroup[] groups = _groups;
+                if ((uint)firstCharacter < (uint)groups.Length)
+                {
+                    ref EntryGroup group = ref groups[firstCharacter];
+                    string? transformed = group.TryGet(inputSpan);
+                    if (transformed is null)
+                    {
+                        string input = inputSpan.ToString();
+                        transformed = _transformation(input);
+                        group.TryAdd(input, transformed);
+                    }
+                    return transformed;
+                }
+            }
+
+            return _transformation(inputSpan.ToString());
+        }
+
+        public string Get(string input)
+        {
+            if ((uint)(input.Length - 1) < InputLengthLimit) // Length: [1, LengthLimit]
+            {
+                int firstCharacter = input[0];
+                EntryGroup[] groups = _groups;
+                if ((uint)firstCharacter < (uint)groups.Length)
+                {
+                    ref EntryGroup group = ref groups[firstCharacter];
+                    string? transformed = group.TryGet(input.AsSpan());
+                    if (transformed is null)
+                    {
+                        transformed = _transformation(input);
+                        group.TryAdd(input, transformed);
+                    }
+                    return transformed;
+                }
+            }
+
+            return _transformation(input);
+        }
+
+        private struct EntryGroup
+        {
+            private struct Entry
+            {
+                public string Input;
+                public string Transformed;
+            }
+
+            private Entry[]? _entries;
+
+            public string? TryGet(ReadOnlySpan<char> inputSpan)
+            {
+                Entry[]? entries = _entries;
+                if (entries is not null)
+                {
+                    for (int i = 0; i < entries.Length; i++)
+                    {
+                        if (inputSpan.SequenceEqual(entries[i].Input.AsSpan()))
+                        {
+                            return entries[i].Transformed;
+                        }
+                    }
+                }
+                return null;
+            }
+
+            public void TryAdd(string input, string transformed)
+            {
+                if (_entries is null)
+                {
+                    Interlocked.CompareExchange(ref _entries, new Entry[MaxEntriesPerCharacter], null);
+                }
+
+                if (_entries[MaxEntriesPerCharacter - 1].Input is null) // There is still space
+                {
+                    lock (_entries)
+                    {
+                        for (int i = 0; i < _entries.Length; i++)
+                        {
+                            string? existingInput = _entries[i].Input;
+
+                            if (existingInput is null)
+                            {
+                                ref Entry entry = ref _entries[i];
+                                Volatile.Write(ref entry.Transformed, transformed);
+                                Volatile.Write(ref entry.Input, input);
+                                break;
+                            }
+
+                            if (input == existingInput)
+                            {
+                                // We lost a race and a different thread already added the same value
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Markdig/Helpers/ValueStringBuilder.cs
+++ b/src/Markdig/Helpers/ValueStringBuilder.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+// Inspired by https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/Text/ValueStringBuilder.cs
+
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Markdig.Helpers
+{
+    internal ref partial struct ValueStringBuilder
+    {
+#if DEBUG
+        public const int StackallocThreshold = 7;
+#else
+#if NET5_0_OR_GREATER
+        // NET5+ has SkipLocalsInit, so allocating more is "free"
+        public const int StackallocThreshold = 256;
+#else
+        public const int StackallocThreshold = 64;
+#endif
+#endif
+
+        private char[]? _arrayToReturnToPool;
+        private Span<char> _chars;
+        private int _pos;
+
+        public ValueStringBuilder(Span<char> initialBuffer)
+        {
+            _arrayToReturnToPool = null;
+            _chars = initialBuffer;
+            _pos = 0;
+        }
+
+        public int Length
+        {
+            get => _pos;
+            set
+            {
+                Debug.Assert(value >= 0);
+                Debug.Assert(value <= _chars.Length);
+                _pos = value;
+            }
+        }
+
+        public ref char this[int index]
+        {
+            get
+            {
+                Debug.Assert(index < _pos);
+                return ref _chars[index];
+            }
+        }
+
+        public override string ToString()
+        {
+            string s = _chars.Slice(0, _pos).ToString();
+            Dispose();
+            return s;
+        }
+
+        public ReadOnlySpan<char> AsSpan() => _chars.Slice(0, _pos);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(char c)
+        {
+            int pos = _pos;
+            Span<char> chars = _chars;
+            if ((uint)pos < (uint)chars.Length)
+            {
+                chars[pos] = c;
+                _pos = pos + 1;
+            }
+            else
+            {
+                GrowAndAppend(c);
+            }
+        }
+
+        public void Append(char c, int count)
+        {
+            if (_pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            Span<char> dst = _chars.Slice(_pos, count);
+            for (int i = 0; i < dst.Length; i++)
+            {
+                dst[i] = c;
+            }
+            _pos += count;
+        }
+
+        public void Append(uint i)
+        {
+            if (i < 10)
+            {
+                Append((char)('0' + i));
+            }
+            else
+            {
+                Append(i.ToString());
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(string s)
+        {
+            int pos = _pos;
+            if (pos > _chars.Length - s.Length)
+            {
+                Grow(s.Length);
+            }
+
+            s
+#if !NET5_0_OR_GREATER
+                .AsSpan()
+#endif
+                .CopyTo(_chars.Slice(pos));
+
+            _pos += s.Length;
+        }
+
+        public void Append(ReadOnlySpan<char> value)
+        {
+            if (_pos > _chars.Length - value.Length)
+            {
+                Grow(value.Length);
+            }
+
+            value.CopyTo(_chars.Slice(_pos));
+            _pos += value.Length;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<char> AppendSpan(int length)
+        {
+            int origPos = _pos;
+            if (origPos > _chars.Length - length)
+            {
+                Grow(length);
+            }
+
+            _pos = origPos + length;
+            return _chars.Slice(origPos, length);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void GrowAndAppend(char c)
+        {
+            Grow(1);
+            Append(c);
+        }
+
+        /// <summary>
+        /// Resize the internal buffer either by doubling current buffer size or
+        /// by adding <paramref name="additionalCapacityBeyondPos"/> to
+        /// <see cref="_pos"/> whichever is greater.
+        /// </summary>
+        /// <param name="additionalCapacityBeyondPos">
+        /// Number of chars requested beyond current position.
+        /// </param>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Grow(int additionalCapacityBeyondPos)
+        {
+            Debug.Assert(additionalCapacityBeyondPos > 0);
+            Debug.Assert(_pos > _chars.Length - additionalCapacityBeyondPos, "Grow called incorrectly, no resize is needed.");
+
+            // Make sure to let Rent throw an exception if the caller has a bug and the desired capacity is negative
+            char[] poolArray = ArrayPool<char>.Shared.Rent((int)Math.Max((uint)(_pos + additionalCapacityBeyondPos), (uint)_chars.Length * 2));
+
+            _chars.Slice(0, _pos).CopyTo(poolArray);
+
+            char[]? toReturn = _arrayToReturnToPool;
+            _chars = _arrayToReturnToPool = poolArray;
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose()
+        {
+            char[]? toReturn = _arrayToReturnToPool;
+            this = default; // for safety, to avoid using pooled array if this instance is erroneously appended to again
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
+    }
+}

--- a/src/Markdig/Markdig.csproj
+++ b/src/Markdig/Markdig.csproj
@@ -7,6 +7,11 @@
     <None Remove="readme.md" />
   </ItemGroup>
   <ItemGroup>
-    <AdditionalFiles Include="readme.md" LunetApiDotNet="true"/>
+    <AdditionalFiles Include="readme.md" LunetApiDotNet="true" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Markdig.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Markdig/Markdig.targets
+++ b/src/Markdig/Markdig.targets
@@ -44,4 +44,8 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.*" PrivateAssets="All"/>
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Markdig.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Markdig/Markdig.targets
+++ b/src/Markdig/Markdig.targets
@@ -44,8 +44,4 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.*" PrivateAssets="All"/>
   </ItemGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="Markdig.Tests" />
-  </ItemGroup>
-
 </Project>

--- a/src/Markdig/Parsers/BlockProcessor.cs
+++ b/src/Markdig/Parsers/BlockProcessor.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Markdig.Helpers;
 using Markdig.Syntax;
 
@@ -592,24 +593,32 @@ namespace Markdig.Parsers
         /// <param name="stackIndex">Index of a block in a stack considered as the last block to update from.</param>
         private void UpdateLastBlockAndContainer(int stackIndex = -1)
         {
-            currentStackIndex = stackIndex < 0 ? OpenedBlocks.Count - 1 : stackIndex;
-            CurrentBlock = null;
-            LastBlock = null;
-            for (int i = OpenedBlocks.Count - 1; i >= 0; i--)
-            {
-                var block = OpenedBlocks[i];
-                if (CurrentBlock is null)
-                {
-                    CurrentBlock = block;
-                }
+            List<Block> openedBlocks = OpenedBlocks;
+            currentStackIndex = stackIndex < 0 ? openedBlocks.Count - 1 : stackIndex;
 
-                if (block is ContainerBlock container)
+            Block? currentBlock = null;
+            for (int i = openedBlocks.Count - 1; i >= 0; i--)
+            {
+                var block = openedBlocks[i];
+                currentBlock ??= block;
+
+                if (block.IsContainerBlock)
                 {
-                    CurrentContainer = container;
-                    LastBlock = CurrentContainer.LastChild;
-                    break;
+                    var currentContainer =
+#if NETSTANDARD2_1
+                        (ContainerBlock)block;
+#else
+                        Unsafe.As<ContainerBlock>(block);
+#endif
+                    CurrentContainer = currentContainer;
+                    LastBlock = currentContainer.LastChild;
+                    CurrentBlock = currentBlock;
+                    return;
                 }
             }
+
+            CurrentBlock = currentBlock;
+            LastBlock = null;
         }
 
         /// <summary>
@@ -639,7 +648,7 @@ namespace Markdig.Parsers
                 ParseIndent();
 
                 // If we have a paragraph block, we want to try to match other blocks before trying the Paragraph
-                if (block is ParagraphBlock)
+                if (block.IsParagraphBlock)
                 {
                     break;
                 }
@@ -675,7 +684,7 @@ namespace Markdig.Parsers
                 }
 
                 // If we have a leaf block
-                if (block is LeafBlock leaf && NewBlocks.Count == 0)
+                if (block.IsLeafBlock && NewBlocks.Count == 0)
                 {
                     ContinueProcessingLine = false;
                     if (!result.IsDiscard())
@@ -689,7 +698,13 @@ namespace Markdig.Parsers
                                 UnwindAllIndents();
                             }
                         }
-                        leaf.AppendLine(ref Line, Column, LineIndex, CurrentLineStartPosition, TrackTrivia);
+
+#if NETSTANDARD2_1
+                        ((LeafBlock)block)
+#else
+                        Unsafe.As<LeafBlock>(block)
+#endif
+                            .AppendLine(ref Line, Column, LineIndex, CurrentLineStartPosition, TrackTrivia);
                     }
                 }
 
@@ -804,7 +819,7 @@ namespace Markdig.Parsers
                     continue;
                 }
 
-                IsLazy = blockParser is ParagraphBlockParser && lastBlock is ParagraphBlock;
+                IsLazy = lastBlock.IsParagraphBlock && blockParser is ParagraphBlockParser;
 
                 var result = IsLazy
                     ? blockParser.TryContinue(this, lastBlock)
@@ -825,7 +840,7 @@ namespace Markdig.Parsers
                 // Special case for paragraph
                 UpdateLastBlockAndContainer();
 
-                if (IsLazy && CurrentBlock is ParagraphBlock paragraph)
+                if (IsLazy && CurrentBlock is { } currentBlock && currentBlock.IsParagraphBlock)
                 {
                     Debug.Assert(NewBlocks.Count == 0);
 
@@ -835,12 +850,18 @@ namespace Markdig.Parsers
                         {
                             UnwindAllIndents();
                         }
-                        paragraph.AppendLine(ref Line, Column, LineIndex, CurrentLineStartPosition, TrackTrivia);
+
+#if NETSTANDARD2_1
+                        ((ParagraphBlock)currentBlock)
+#else
+                        Unsafe.As<ParagraphBlock>(currentBlock)
+#endif
+                            .AppendLine(ref Line, Column, LineIndex, CurrentLineStartPosition, TrackTrivia);
                     }
                     if (TrackTrivia)
                     {
                         // special case: take care when refactoring this
-                        if (paragraph.Parent is QuoteBlock qb)
+                        if (currentBlock.Parent is QuoteBlock qb)
                         {
                             var triviaAfter = UseTrivia(Start - 1);
                             qb.QuoteLines.Last().TriviaAfter = triviaAfter;
@@ -893,20 +914,24 @@ namespace Markdig.Parsers
                 block.Line = LineIndex;
 
                 // If we have a leaf block
-                var leaf = block as LeafBlock;
-                if (leaf != null)
+                if (block.IsLeafBlock)
                 {
                     if (!result.IsDiscard())
                     {
                         if (TrackTrivia)
                         {
-                            if (block is ParagraphBlock ||
-                                block is HtmlBlock)
+                            if (block.IsParagraphBlock || block is HtmlBlock)
                             {
                                 UnwindAllIndents();
                             }
                         }
-                        leaf.AppendLine(ref Line, Column, LineIndex, CurrentLineStartPosition, TrackTrivia);
+
+#if NETSTANDARD2_1
+                        ((LeafBlock)block)
+#else
+                        Unsafe.As<LeafBlock>(block)
+#endif
+                            .AppendLine(ref Line, Column, LineIndex, CurrentLineStartPosition, TrackTrivia);
                     }
 
                     if (newBlocks.Count > 0)
@@ -934,7 +959,7 @@ namespace Markdig.Parsers
                 // Add a block BlockProcessor to the stack (and leave it opened)
                 OpenedBlocks.Add(block);
 
-                if (leaf != null)
+                if (block.IsLeafBlock)
                 {
                     ContinueProcessingLine = false;
                     return;

--- a/src/Markdig/Parsers/FencedBlockParserBase.cs
+++ b/src/Markdig/Parsers/FencedBlockParserBase.cs
@@ -3,6 +3,7 @@
 // See the license.txt file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using Markdig.Helpers;
 using Markdig.Renderers.Html;
 using Markdig.Syntax;
@@ -311,7 +312,8 @@ namespace Markdig.Parsers
             // Add the language as an attribute by default
             if (!string.IsNullOrEmpty(fenced.Info))
             {
-                string infoWithPrefix = _infoPrefixCache?.Get(fenced.Info) ?? fenced.Info;
+                Debug.Assert(_infoPrefixCache is not null || InfoPrefix is null);
+                string infoWithPrefix = _infoPrefixCache?.Get(fenced.Info!) ?? fenced.Info!;
                 fenced.GetAttributes().AddClass(infoWithPrefix);
             }
 

--- a/src/Markdig/Parsers/HtmlBlockParser.cs
+++ b/src/Markdig/Parsers/HtmlBlockParser.cs
@@ -62,10 +62,10 @@ namespace Markdig.Parsers
 
         private BlockState TryParseTagType7(BlockProcessor state, StringSlice line, int startColumn, int startPosition)
         {
-            var builder = StringBuilderCache.Local();
+            var builder = new ValueStringBuilder(stackalloc char[ValueStringBuilder.StackallocThreshold]);
             var c = line.CurrentChar;
             var result = BlockState.None;
-            if ((c == '/' && HtmlHelper.TryParseHtmlCloseTag(ref line, builder)) || HtmlHelper.TryParseHtmlTagOpenTag(ref line, builder))
+            if ((c == '/' && HtmlHelper.TryParseHtmlCloseTag(ref line, ref builder)) || HtmlHelper.TryParseHtmlTagOpenTag(ref line, ref builder))
             {
                 // Must be followed by whitespace only
                 bool hasOnlySpaces = true;
@@ -90,7 +90,7 @@ namespace Markdig.Parsers
                 }
             }
 
-            builder.Length = 0;
+            builder.Dispose();
             return result;
         }
 

--- a/src/Markdig/Parsers/IndentedCodeBlockParser.cs
+++ b/src/Markdig/Parsers/IndentedCodeBlockParser.cs
@@ -17,7 +17,7 @@ namespace Markdig.Parsers
     {
         public override bool CanInterrupt(BlockProcessor processor, Block block)
         {
-            return !(block is ParagraphBlock);
+            return !block.IsParagraphBlock;
         }
 
         public override BlockState TryOpen(BlockProcessor processor)

--- a/src/Markdig/Parsers/InlineProcessor.cs
+++ b/src/Markdig/Parsers/InlineProcessor.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Runtime.CompilerServices;
 using Markdig.Helpers;
 using Markdig.Parsers.Inlines;
 using Markdig.Syntax;
@@ -321,9 +322,14 @@ namespace Markdig.Parsers
             var container = Block!.Inline!;
             for (int depth = 0; ; depth++)
             {
-                if (container.LastChild is ContainerInline nextContainer && !nextContainer.IsClosed)
+                Inline? lastChild = container.LastChild;
+                if (lastChild is not null && lastChild.IsContainerInline && !lastChild.IsClosed)
                 {
-                    container = nextContainer;
+#if NETSTANDARD2_1
+                    container = ((ContainerInline)lastChild);
+#else
+                    container = Unsafe.As<ContainerInline>(lastChild);
+#endif
                 }
                 else
                 {

--- a/src/Markdig/Parsers/Inlines/CodeInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/CodeInlineParser.cs
@@ -40,7 +40,7 @@ namespace Markdig.Parsers.Inlines
 
             char c = slice.CurrentChar;
 
-            var builder = StringBuilderCache.Local();
+            var builder = new ValueStringBuilder(stackalloc char[ValueStringBuilder.StackallocThreshold]);
 
             // A backtick string is a string of one or more backtick characters (`) that is neither preceded nor followed by a backtick.
             // A code span begins with a backtick string and ends with a backtick string of equal length.
@@ -98,17 +98,15 @@ namespace Markdig.Parsers.Inlines
             bool isMatching = false;
             if (closeSticks == openSticks)
             {
-                string content;
+                ReadOnlySpan<char> contentSpan = builder.AsSpan();
 
                 // Remove one space from front and back if the string is not all spaces
-                if (!allSpace && builder.Length > 2 && builder[0] == ' ' && builder[builder.Length - 1] == ' ')
+                if (!allSpace && contentSpan.Length > 2 && contentSpan[0] == ' ' && contentSpan[contentSpan.Length - 1] == ' ')
                 {
-                    content = builder.ToString(1, builder.Length - 2);
+                    contentSpan = contentSpan.Slice(1, contentSpan.Length - 2);
                 }
-                else
-                {
-                    content = builder.ToString();
-                }
+
+                string content = contentSpan.ToString();
 
                 int delimiterCount = Math.Min(openSticks, closeSticks);
                 var spanStart = processor.GetSourcePosition(startPosition, out int line, out int column);
@@ -131,6 +129,7 @@ namespace Markdig.Parsers.Inlines
                 isMatching = true;
             }
 
+            builder.Dispose();
             return isMatching;
         }
     }

--- a/src/Markdig/Parsers/Inlines/EmphasisInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/EmphasisInlineParser.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Markdig.Helpers;
 using Markdig.Renderers.Html;
 using Markdig.Syntax;
@@ -91,10 +92,16 @@ namespace Markdig.Parsers.Inlines
 
         public bool PostProcess(InlineProcessor state, Inline? root, Inline? lastChild, int postInlineProcessorIndex, bool isFinalProcessing)
         {
-            if (!(root is ContainerInline container))
+            if (root is null || !root.IsContainerInline)
             {
                 return true;
             }
+
+#if NETSTANDARD2_1
+            ContainerInline container = (ContainerInline)root;
+#else
+            ContainerInline container = Unsafe.As<ContainerInline>(root);
+#endif
 
             List<EmphasisDelimiterInline>? delimiters = null;
             if (container is EmphasisDelimiterInline emphasisDelimiter)

--- a/src/Markdig/Parsers/Inlines/LineBreakInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LineBreakInlineParser.cs
@@ -30,7 +30,7 @@ namespace Markdig.Parsers.Inlines
         public override bool Match(InlineProcessor processor, ref StringSlice slice)
         {
             // Hard line breaks are for separating inline content within a block. Neither syntax for hard line breaks works at the end of a paragraph or other block element:
-            if (!(processor.Block is ParagraphBlock))
+            if (!processor.Block!.IsParagraphBlock)
             {
                 return false;
             }

--- a/src/Markdig/Parsers/ListBlockParser.cs
+++ b/src/Markdig/Parsers/ListBlockParser.cs
@@ -263,10 +263,11 @@ namespace Markdig.Parsers
             // Starts/continue the list unless:
             // - an empty list item follows a paragraph
             // - an ordered list is not starting by '1'
-            if ((block ?? state.LastBlock) is ParagraphBlock previousParagraph)
+            block ??= state.LastBlock;
+            if (block is not null && block.IsParagraphBlock)
             {
                 if (state.IsBlankLine ||
-                    state.IsOpen(previousParagraph) && listInfo.BulletType == '1' && listInfo.OrderedStart is not "1")
+                    state.IsOpen(block) && listInfo.BulletType == '1' && listInfo.OrderedStart is not "1")
                 {
                     state.GoToColumn(initColumn);
                     state.TriviaStart = savedTriviaStart; // restore changed TriviaStart state

--- a/src/Markdig/Parsers/MarkdownParser.cs
+++ b/src/Markdig/Parsers/MarkdownParser.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Markdig.Helpers;
 using Markdig.Syntax;
 
@@ -149,8 +150,14 @@ namespace Markdig.Parsers
                 for (; item.Index < container.Count; item.Index++)
                 {
                     var block = container[item.Index];
-                    if (block is LeafBlock leafBlock)
+                    if (block.IsLeafBlock)
                     {
+#if NETSTANDARD2_1
+                        LeafBlock leafBlock = (LeafBlock)block;
+#else
+                        LeafBlock leafBlock = Unsafe.As<LeafBlock>(block);
+#endif
+
                         leafBlock.OnProcessInlinesBegin(inlineProcessor);
                         if (leafBlock.ProcessInlines)
                         {
@@ -167,10 +174,10 @@ namespace Markdig.Parsers
                         }
                         leafBlock.OnProcessInlinesEnd(inlineProcessor);
                     }
-                    else if (block is ContainerBlock newContainer)
+                    else if (block.IsContainerBlock)
                     {
                         // If we need to remove it
-                        if (newContainer.RemoveAfterProcessInlines)
+                        if (block.RemoveAfterProcessInlines)
                         {
                             container.RemoveAt(item.Index);
                         }
@@ -185,8 +192,12 @@ namespace Markdig.Parsers
                             Array.Resize(ref blocks, blockCount * 2);
                             ThrowHelper.CheckDepthLimit(blocks.Length);
                         }
-                        blocks[blockCount++] = new ContainerItem(newContainer);
-                        newContainer.OnProcessInlinesBegin(inlineProcessor);
+#if NETSTANDARD2_1
+                        blocks[blockCount++] = new ContainerItem((ContainerBlock)block);
+#else
+                        blocks[blockCount++] = new ContainerItem(Unsafe.As<ContainerBlock>(block));
+#endif
+                        block.OnProcessInlinesBegin(inlineProcessor);
                         goto process_new_block;
                     }
                 }

--- a/src/Markdig/SkipLocalsInit.cs
+++ b/src/Markdig/SkipLocalsInit.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+#if NET5_0_OR_GREATER
+[module: System.Runtime.CompilerServices.SkipLocalsInit]
+#endif

--- a/src/Markdig/Syntax/Block.cs
+++ b/src/Markdig/Syntax/Block.cs
@@ -38,6 +38,10 @@ namespace Markdig.Syntax
         /// </summary>
         public BlockParser? Parser { get; }
 
+        internal bool IsContainerBlock { get; private protected set; }
+        internal bool IsLeafBlock { get; private protected set; }
+        internal bool IsParagraphBlock { get; private protected set; }
+
         /// <summary>
         /// Gets or sets a value indicating whether this instance is still open.
         /// </summary>
@@ -132,9 +136,14 @@ namespace Markdig.Syntax
 
         internal static Block FindRootMostContainerParent(Block block)
         {
-            while (block.Parent is ContainerBlock && block.Parent is not MarkdownDocument)
+            while (true)
             {
-                block = block.Parent;
+                Block? parent = block.Parent;
+                if (parent is null || !parent.IsContainerBlock || parent is MarkdownDocument)
+                {
+                    break;
+                }
+                block = parent;
             }
             return block;
         }

--- a/src/Markdig/Syntax/ContainerBlock.cs
+++ b/src/Markdig/Syntax/ContainerBlock.cs
@@ -28,6 +28,7 @@ namespace Markdig.Syntax
         protected ContainerBlock(BlockParser? parser) : base(parser)
         {
             children = ArrayHelper.Empty<Block>();
+            IsContainerBlock = true;
         }
 
         /// <summary>

--- a/src/Markdig/Syntax/Inlines/ContainerInline.cs
+++ b/src/Markdig/Syntax/Inlines/ContainerInline.cs
@@ -17,6 +17,11 @@ namespace Markdig.Syntax.Inlines
     /// <seealso cref="Inline" />
     public class ContainerInline : Inline, IEnumerable<Inline>
     {
+        public ContainerInline()
+        {
+            IsContainerInline = true;
+        }
+
         /// <summary>
         /// Gets the parent block of this inline.
         /// </summary>

--- a/src/Markdig/Syntax/Inlines/Inline.cs
+++ b/src/Markdig/Syntax/Inlines/Inline.cs
@@ -30,6 +30,8 @@ namespace Markdig.Syntax.Inlines
         /// </summary>
         public Inline? NextSibling { get; internal set; }
 
+        internal bool IsContainerInline { get; private protected set; }
+
         /// <summary>
         /// Gets or sets a value indicating whether this instance is closed.
         /// </summary>

--- a/src/Markdig/Syntax/LeafBlock.cs
+++ b/src/Markdig/Syntax/LeafBlock.cs
@@ -80,28 +80,20 @@ namespace Markdig.Syntax
             {
                 Lines = new StringLineGroup(4, ProcessInlines);
             }
+
             var stringLine = new StringLine(ref slice, line, column, sourceLinePosition, slice.NewLine);
-            // Regular case, we are not in the middle of a tab
-            if (slice.CurrentChar != '\t' || !CharHelper.IsAcrossTab(column))
+            // Regular case: we are not in the middle of a tab
+
+            if (slice.CurrentChar == '\t' && CharHelper.IsAcrossTab(column) && !trackTrivia)
             {
-                Lines.Add(ref stringLine);
+                // We need to expand tabs to spaces
+                var builder = new ValueStringBuilder(stackalloc char[ValueStringBuilder.StackallocThreshold]);
+                builder.Append(' ', CharHelper.AddTab(column) - column);
+                builder.Append(slice.AsSpan().Slice(1));
+                stringLine.Slice = new StringSlice(builder.ToString());
             }
-            else
-            {
-                var builder = StringBuilderCache.Local();
-                if (trackTrivia)
-                {
-                    builder.Append(slice.Text, slice.Start, slice.Length);
-                }
-                else
-                {
-                    // We need to expand tabs to spaces
-                    builder.Append(' ', CharHelper.AddTab(column) - column);
-                    builder.Append(slice.Text, slice.Start + 1, slice.Length - 1);
-                }
-                stringLine.Slice = new StringSlice(builder.GetStringAndReset());
-                Lines.Add(ref stringLine);
-            }
+
+            Lines.Add(ref stringLine);
             NewLine = slice.NewLine; // update newline, as it should be the last newline of the block
         }
     }

--- a/src/Markdig/Syntax/LeafBlock.cs
+++ b/src/Markdig/Syntax/LeafBlock.cs
@@ -24,6 +24,7 @@ namespace Markdig.Syntax
         /// <param name="parser">The parser used to create this block.</param>
         protected LeafBlock(BlockParser? parser) : base(parser)
         {
+            IsLeafBlock = true;
         }
 
         /// <summary>

--- a/src/Markdig/Syntax/ParagraphBlock.cs
+++ b/src/Markdig/Syntax/ParagraphBlock.cs
@@ -29,6 +29,7 @@ namespace Markdig.Syntax
         {
             // Inlines are processed for a paragraph
             ProcessInlines = true;
+            IsParagraphBlock = true;
         }
 
         public int LastLine => Line + Lines.Count - 1;


### PR DESCRIPTION
- Caching the `FencedCodeBlock.InfoString` & language-prefixed strings
- Using `ValueStringBuilder` over `StringBuilderCache.Local()`
- Avoiding the cost of type checks & casting for `ContainerBlock`, `LeafBlock`, `ParagraphBlock` and `ContainerInline` by setting flags on the base type instead (this is a ~5% CPU win by removing [`S.R.CompilerServices.CastHelpers.IsInstanceOfClass`](https://github.com/dotnet/runtime/blob/2f13361ba7d4cef84acae24751a3c367c1a6ab89/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs#L277)).
- Improved `StringLineGroup.NextChar` - very hot method for `LinkHelper`

Parsing [this document](https://github.com/microsoft/reverse-proxy/blob/main/docs/docfx/articles/distributed-tracing.md) with `PreciseSourceLocation`:

Before

| Method |     SourceText |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------- |--------------- |---------:|---------:|---------:|-------:|----------:|
|  Parse | TracingArticle | 42.77 us | 0.232 us | 0.332 us | 4.4556 |     18 KB |

After

| Method |     SourceText |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------- |--------------- |---------:|---------:|---------:|-------:|----------:|
|  Parse | TracingArticle | 37.39 us | 0.215 us | 0.309 us | 4.3945 |     18 KB |