### PR TITLE
ContainerBlock CopyTo IndexOutOfRangeException

### DIFF
--- a/src/Markdig.Tests/TestContainerBlocks.cs
+++ b/src/Markdig.Tests/TestContainerBlocks.cs
@@ -88,5 +88,25 @@ namespace Markdig.Tests
 
             Assert.Throws<ArgumentException>(() => container[0] = two); // two already has a parent
         }
+
+        [Test]
+        public void CopyToCopiesChildren()
+        {
+            ContainerBlock container = new MockContainerBlock();
+            var one = new ParagraphBlock();
+            container.Add(one);
+            var two = new ParagraphBlock();
+            container.Add(two);
+            var three = new ParagraphBlock();
+            container.Add(three);
+            Assert.AreEqual(3, container.Count);
+
+            var destination = new Block[3];
+            container.CopyTo(destination, 0);
+
+            Assert.AreSame(destination[0], one);
+            Assert.AreSame(destination[1], two);
+            Assert.AreSame(destination[2], three);
+        }
     }
 }

--- a/src/Markdig/Syntax/ContainerBlock.cs
+++ b/src/Markdig/Syntax/ContainerBlock.cs
@@ -130,7 +130,7 @@ namespace Markdig.Syntax
             BlockWrapper[] children = _children;
             for (int i = 0; i < Count && i < children.Length; i++)
             {
-                array[arrayIndex + 1] = children[i].Block;
+                array[arrayIndex + i] = children[i].Block;
             }
         }
 


### PR DESCRIPTION
Ref: https://github.com/xoofx/markdig/issues/628

`ToList()` operation on container blocks throws IndexOutOfRangeException or MarkdownDocument copies values incorrectly.
Fixing typo in the CopyTo method of ContainerBlocks.
Adding a unit test