### PR TITLE
Reduce the overhead of Parse calls

### DIFF
--- a/src/Markdig/Helpers/ObjectCache.cs
+++ b/src/Markdig/Helpers/ObjectCache.cs
@@ -3,7 +3,7 @@
 // See the license.txt file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace Markdig.Helpers
 {
@@ -13,14 +13,14 @@ namespace Markdig.Helpers
     /// <typeparam name="T">Type of the object to cache</typeparam>
     public abstract class ObjectCache<T> where T : class
     {
-        private readonly Stack<T> builders;
+        private readonly ConcurrentQueue<T> _builders;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectCache{T}"/> class.
         /// </summary>
         protected ObjectCache()
         {
-            builders = new Stack<T>(4);
+            _builders = new ConcurrentQueue<T>();
         }
 
         /// <summary>
@@ -28,10 +28,7 @@ namespace Markdig.Helpers
         /// </summary>
         public void Clear()
         {
-            lock (builders)
-            {
-                builders.Clear();
-            }
+            _builders.Clear();
         }
 
         /// <summary>
@@ -40,12 +37,9 @@ namespace Markdig.Helpers
         /// <returns></returns>
         public T Get()
         {
-            lock (builders)
+            if (_builders.TryDequeue(out T instance))
             {
-                if (builders.Count > 0)
-                {
-                    return builders.Pop();
-                }
+                return instance;
             }
 
             return NewInstance();
@@ -60,10 +54,7 @@ namespace Markdig.Helpers
         {
             if (instance is null) ThrowHelper.ArgumentNullException(nameof(instance));
             Reset(instance);
-            lock (builders)
-            {
-                builders.Push(instance);
-            }
+            _builders.Enqueue(instance);
         }
 
         /// <summary>

--- a/src/Markdig/Markdown.cs
+++ b/src/Markdig/Markdown.cs
@@ -6,7 +6,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using Markdig.Extensions.SelfPipeline;
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Renderers;
@@ -41,11 +40,11 @@ namespace Markdig
                 return DefaultPipeline;
             }
 
-            var selfPipeline = pipeline.Extensions.Find<SelfPipelineExtension>();
-            if (selfPipeline is not null)
+            if (pipeline.SelfPipeline is not null)
             {
-                return selfPipeline.CreatePipelineFromInput(markdown);
+                return pipeline.SelfPipeline.CreatePipelineFromInput(markdown);
             }
+
             return pipeline;
         }
 

--- a/src/Markdig/MarkdownPipeline.cs
+++ b/src/Markdig/MarkdownPipeline.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.IO;
-using System.Text;
+using Markdig.Extensions.SelfPipeline;
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Renderers;
@@ -13,11 +13,10 @@ namespace Markdig
 {
     /// <summary>
     /// This class is the Markdown pipeline build from a <see cref="MarkdownPipelineBuilder"/>.
+    /// <para>An instance of <see cref="MarkdownPipeline"/> is immutable, thread-safe, and should be reused when parsing multiple inputs.</para>
     /// </summary>
     public sealed class MarkdownPipeline
     {
-        // This class is immutable
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MarkdownPipeline" /> class.
         /// </summary>
@@ -36,6 +35,8 @@ namespace Markdig
             InlineParsers = inlineParsers;
             DebugLog = debugLog;
             DocumentProcessed = documentProcessed;
+
+            SelfPipeline = Extensions.Find<SelfPipelineExtension>();
         }
 
         internal bool PreciseSourceLocation { get; set; }
@@ -53,6 +54,8 @@ namespace Markdig
         internal TextWriter? DebugLog { get; }
 
         internal ProcessDocumentDelegate? DocumentProcessed;
+
+        internal SelfPipelineExtension? SelfPipeline;
 
         /// <summary>
         /// True to parse trivia such as whitespace, extra heading characters and unescaped

--- a/src/Markdig/Polyfills/ConcurrentQueue.cs
+++ b/src/Markdig/Polyfills/ConcurrentQueue.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+#if NET452 || NETSTANDARD2_0
+namespace System.Collections.Concurrent
+{
+    internal static class ConcurrentQueueExtensions
+    {
+        public static void Clear<T>(this ConcurrentQueue<T> queue)
+        {
+            while (queue.TryDequeue(out _)) { }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Saves 8 % (~65 ns) on my machine when parsing `Markdown.Parse("foo", _pipeline)` with 
```c#
new MarkdownPipelineBuilder().UsePreciseSourceLocation();
```

and 15 % (~150 ns) with `UseAdvancedExtensions`.