### PR TITLE
added support for ToPlainText for pipetables extension

### DIFF
--- a/src/Markdig.Tests/TestPlainText.cs
+++ b/src/Markdig.Tests/TestPlainText.cs
@@ -15,7 +15,7 @@ namespace Markdig.Tests
         [TestCase(/* markdownText: */ "# foo\nbar", /* expected: */ "foo\nbar\n")]
         [TestCase(/* markdownText: */ "> foo", /* expected: */ "foo\n")]
         [TestCase(/* markdownText: */ "> foo\nbar\n> baz", /* expected: */ "foo\nbar\nbaz\n")]
-        [TestCase(/* markdownText: */ "`foo`", /* expected: */ "foo\n")]        
+        [TestCase(/* markdownText: */ "`foo`", /* expected: */ "foo\n")]
         [TestCase(/* markdownText: */ "`foo\nbar`", /* expected: */ "foo bar\n")] // new line within codespan is treated as whitespace (Example317)
         [TestCase(/* markdownText: */ "```\nfoo bar\n```", /* expected: */ "foo bar\n")]
         [TestCase(/* markdownText: */ "- foo\n- bar\n- baz", /* expected: */ "foo\nbar\nbaz\n")]
@@ -23,7 +23,7 @@ namespace Markdig.Tests
         [TestCase(/* markdownText: */ "- foo&lt;baz", /* expected: */ "foo<baz\n")]
         [TestCase(/* markdownText: */ "## foo `bar::baz >`", /* expected: */ "foo bar::baz >\n")]
         public void TestPlainEnsureNewLine(string markdownText, string expected)
-        {            
+        {
             var actual = Markdown.ToPlainText(markdownText);
             Assert.AreEqual(expected, actual);
         }
@@ -31,6 +31,7 @@ namespace Markdig.Tests
         [Test]
         [TestCase(/* markdownText: */ ":::\nfoo\n:::", /* expected: */ "foo\n", /*extensions*/ "customcontainers|advanced")]
         [TestCase(/* markdownText: */ ":::bar\nfoo\n:::", /* expected: */ "foo\n", /*extensions*/ "customcontainers+attributes|advanced")]
+        [TestCase(/* markdownText: */ "| Header1 | Header2 | Header3 |\n|--|--|--|\nt**es**t|value2|value3", /* expected: */ "Header1 Header2 Header3 test value2 value3","pipetables")]
         public void TestPlainWithExtensions(string markdownText, string expected, string extensions)
         {
             TestParser.TestSpec(markdownText, expected, extensions, plainText: true);

--- a/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
+++ b/src/Markdig/Extensions/Tables/HtmlTableRenderer.cs
@@ -17,122 +17,154 @@ namespace Markdig.Extensions.Tables
     {
         protected override void Write(HtmlRenderer renderer, Table table)
         {
-            renderer.EnsureLine();
-            renderer.Write("<table").WriteAttributes(table).WriteLine('>');
-
-            bool hasBody = false;
-            bool hasAlreadyHeader = false;
-            bool isHeaderOpen = false;
-
-
-            bool hasColumnWidth = false;
-            foreach (var tableColumnDefinition in table.ColumnDefinitions)
+            if (renderer.EnableHtmlForBlock)
             {
-                if (tableColumnDefinition.Width != 0.0f && tableColumnDefinition.Width != 1.0f)
-                {
-                    hasColumnWidth = true;
-                    break;
-                }
-            }
+                renderer.EnsureLine();
+                renderer.Write("<table").WriteAttributes(table).WriteLine('>');
 
-            if (hasColumnWidth)
-            {
+                bool hasBody = false;
+                bool hasAlreadyHeader = false;
+                bool isHeaderOpen = false;
+
+
+                bool hasColumnWidth = false;
                 foreach (var tableColumnDefinition in table.ColumnDefinitions)
                 {
-                    var width = Math.Round(tableColumnDefinition.Width*100)/100;
-                    var widthValue = string.Format(CultureInfo.InvariantCulture, "{0:0.##}", width);
-                    renderer.WriteLine($"<col style=\"width:{widthValue}%\" />");
+                    if (tableColumnDefinition.Width != 0.0f && tableColumnDefinition.Width != 1.0f)
+                    {
+                        hasColumnWidth = true;
+                        break;
+                    }
                 }
-            }
 
-            foreach (var rowObj in table)
-            {
-                var row = (TableRow)rowObj;
-                if (row.IsHeader)
+                if (hasColumnWidth)
                 {
-                    // Allow a single thead
-                    if (!hasAlreadyHeader)
+                    foreach (var tableColumnDefinition in table.ColumnDefinitions)
                     {
-                        renderer.WriteLine("<thead>");
-                        isHeaderOpen = true;
+                        var width = Math.Round(tableColumnDefinition.Width * 100) / 100;
+                        var widthValue = string.Format(CultureInfo.InvariantCulture, "{0:0.##}", width);
+                        renderer.WriteLine($"<col style=\"width:{widthValue}%\" />");
                     }
-                    hasAlreadyHeader = true;
                 }
-                else if (!hasBody)
-                {
-                    if (isHeaderOpen)
-                    {
-                        renderer.WriteLine("</thead>");
-                        isHeaderOpen = false;
-                    }
 
-                    renderer.WriteLine("<tbody>");
-                    hasBody = true;
-                }
-                renderer.Write("<tr").WriteAttributes(row).WriteLine('>');
-                for (int i = 0; i < row.Count; i++)
+                foreach (var rowObj in table)
                 {
-                    var cellObj = row[i];
-                    var cell = (TableCell)cellObj;
-
-                    renderer.EnsureLine();
-                    renderer.Write(row.IsHeader ? "<th" : "<td");
-                    if (cell.ColumnSpan != 1)
+                    var row = (TableRow)rowObj;
+                    if (row.IsHeader)
                     {
-                        renderer.Write($" colspan=\"{cell.ColumnSpan}\"");
-                    }
-                    if (cell.RowSpan != 1)
-                    {
-                        renderer.Write($" rowspan=\"{cell.RowSpan}\"");
-                    }
-                    if (table.ColumnDefinitions.Count > 0)
-                    {
-                        var columnIndex = cell.ColumnIndex < 0 || cell.ColumnIndex >= table.ColumnDefinitions.Count
-                            ? i
-                            : cell.ColumnIndex;
-                        columnIndex = columnIndex >= table.ColumnDefinitions.Count ? table.ColumnDefinitions.Count - 1 : columnIndex;
-                        var alignment = table.ColumnDefinitions[columnIndex].Alignment;
-                        if (alignment.HasValue)
+                        // Allow a single thead
+                        if (!hasAlreadyHeader)
                         {
-                            switch (alignment)
+                            renderer.WriteLine("<thead>");
+                            isHeaderOpen = true;
+                        }
+
+                        hasAlreadyHeader = true;
+                    }
+                    else if (!hasBody)
+                    {
+                        if (isHeaderOpen)
+                        {
+                            renderer.WriteLine("</thead>");
+                            isHeaderOpen = false;
+                        }
+
+                        renderer.WriteLine("<tbody>");
+                        hasBody = true;
+                    }
+
+                    renderer.Write("<tr").WriteAttributes(row).WriteLine('>');
+                    for (int i = 0; i < row.Count; i++)
+                    {
+                        var cellObj = row[i];
+                        var cell = (TableCell)cellObj;
+
+                        renderer.EnsureLine();
+                        renderer.Write(row.IsHeader ? "<th" : "<td");
+                        if (cell.ColumnSpan != 1)
+                        {
+                            renderer.Write($" colspan=\"{cell.ColumnSpan}\"");
+                        }
+
+                        if (cell.RowSpan != 1)
+                        {
+                            renderer.Write($" rowspan=\"{cell.RowSpan}\"");
+                        }
+
+                        if (table.ColumnDefinitions.Count > 0)
+                        {
+                            var columnIndex = cell.ColumnIndex < 0 || cell.ColumnIndex >= table.ColumnDefinitions.Count
+                                ? i
+                                : cell.ColumnIndex;
+                            columnIndex = columnIndex >= table.ColumnDefinitions.Count ? table.ColumnDefinitions.Count - 1 : columnIndex;
+                            var alignment = table.ColumnDefinitions[columnIndex].Alignment;
+                            if (alignment.HasValue)
                             {
-                                case TableColumnAlign.Center:
-                                    renderer.Write(" style=\"text-align: center;\"");
-                                    break;
-                                case TableColumnAlign.Right:
-                                    renderer.Write(" style=\"text-align: right;\"");
-                                    break;
-                                case TableColumnAlign.Left:
-                                    renderer.Write(" style=\"text-align: left;\"");
-                                    break;
+                                switch (alignment)
+                                {
+                                    case TableColumnAlign.Center:
+                                        renderer.Write(" style=\"text-align: center;\"");
+                                        break;
+                                    case TableColumnAlign.Right:
+                                        renderer.Write(" style=\"text-align: right;\"");
+                                        break;
+                                    case TableColumnAlign.Left:
+                                        renderer.Write(" style=\"text-align: left;\"");
+                                        break;
+                                }
                             }
                         }
-                    }
-                    renderer.WriteAttributes(cell);
-                    renderer.Write('>');
 
-                    var previousImplicitParagraph = renderer.ImplicitParagraph;
-                    if (cell.Count == 1)
-                    {
-                        renderer.ImplicitParagraph = true;
-                    }
-                    renderer.Write(cell);
-                    renderer.ImplicitParagraph = previousImplicitParagraph;
+                        renderer.WriteAttributes(cell);
+                        renderer.Write('>');
 
-                    renderer.WriteLine(row.IsHeader ? "</th>" : "</td>");
+                        var previousImplicitParagraph = renderer.ImplicitParagraph;
+                        if (cell.Count == 1)
+                        {
+                            renderer.ImplicitParagraph = true;
+                        }
+
+                        renderer.Write(cell);
+                        renderer.ImplicitParagraph = previousImplicitParagraph;
+
+                        renderer.WriteLine(row.IsHeader ? "</th>" : "</td>");
+                    }
+
+                    renderer.WriteLine("</tr>");
                 }
-                renderer.WriteLine("</tr>");
-            }
 
-            if (hasBody)
-            {
-                renderer.WriteLine("</tbody>");
+                if (hasBody)
+                {
+                    renderer.WriteLine("</tbody>");
+                }
+                else if (isHeaderOpen)
+                {
+                    renderer.WriteLine("</thead>");
+                }
+
+                renderer.WriteLine("</table>");
             }
-            else if (isHeaderOpen)
+            else
             {
-                renderer.WriteLine("</thead>");
+                //no html, just write the table contents
+                var impliciParagraph = renderer.ImplicitParagraph;
+
+                //enable implicit paragraphs to avoid newlines after each cell
+                renderer.ImplicitParagraph = true;
+                foreach (var rowObj in table)
+                {
+                    var row = (TableRow)rowObj;
+                    for (int i = 0; i < row.Count; i++)
+                    {
+                        var cellObj = row[i];
+                        var cell = (TableCell)cellObj;
+                        renderer.Write(cell);
+                        //write a space after each cell to avoid text being merged with the next cell
+                        renderer.Write(' ');
+                    }
+                }
+                renderer.ImplicitParagraph = impliciParagraph;
             }
-            renderer.WriteLine("</table>");
         }
     }
 }


### PR DESCRIPTION
This PR adds support for `ToPlainText` for the pipetables extension. Before this, it would simply return all the table html elements, and render plaintext within the table. With this PR, all the table elements are removed from the plaintext output as you would expect as a result of `ToPlainText`