### PR TITLE
Fix ANE when parsing empty documents with trackTrivia enabled

### DIFF
--- a/src/Markdig.Tests/TestParser.cs
+++ b/src/Markdig.Tests/TestParser.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Markdig.Extensions.JiraLinks;
+using Markdig.Renderers.Roundtrip;
 using Markdig.Syntax;
 using NUnit.Framework;
 
@@ -65,6 +66,15 @@ namespace Markdig.Tests
             }
 
             TestDescendantsOrder.TestSchemas(specsSyntaxTrees);
+        }
+
+        [Test]
+        public void ParseEmptyDocumentWithTrackTriviaEnabled()
+        {
+            var document = Markdown.Parse("", trackTrivia: true);
+            using var sw = new StringWriter();
+            new RoundtripRenderer(sw).Render(document);
+            Assert.AreEqual("", sw.ToString());
         }
 
         public static void TestSpec(string inputText, string expectedOutputText, string extensions = null, bool plainText = false, string context = null)

--- a/src/Markdig/Parsers/MarkdownParser.cs
+++ b/src/Markdig/Parsers/MarkdownParser.cs
@@ -65,7 +65,11 @@ namespace Markdig.Parsers
                         var noBlocksFoundBlock = new EmptyBlock(null);
                         List<StringSlice> linesBefore = blockProcessor.UseLinesBefore();
                         noBlocksFoundBlock.LinesAfter = new List<StringSlice>();
-                        noBlocksFoundBlock.LinesAfter.AddRange(linesBefore);
+                        if (linesBefore != null)
+                        {
+                            noBlocksFoundBlock.LinesAfter.AddRange(linesBefore);
+                        }
+
                         document.Add(noBlocksFoundBlock);
                     }
                     else if (lastBlock != null && blockProcessor.LinesBefore != null)


### PR DESCRIPTION
Fix #665 