### PR TITLE
Use Span.Fill instead of for loop in ValueStringBuilder.Append

### DIFF
--- a/src/Markdig/Helpers/ValueStringBuilder.cs
+++ b/src/Markdig/Helpers/ValueStringBuilder.cs
@@ -87,11 +87,7 @@ namespace Markdig.Helpers
                 Grow(count);
             }
 
-            Span<char> dst = _chars.Slice(_pos, count);
-            for (int i = 0; i < dst.Length; i++)
-            {
-                dst[i] = c;
-            }
+            _chars.Slice(_pos, count).Fill(c);
             _pos += count;
         }
 


### PR DESCRIPTION
This PR replaces manual for loop in ValueStringBuilder.Append with Span.Fill, which is much faster on big buffers due to vectorization.