### PR TITLE
Drop netcoreapp3.1 target

### DIFF
--- a/src/Markdig/Markdig.targets
+++ b/src/Markdig/Markdig.targets
@@ -7,7 +7,7 @@
     <Authors>Alexandre Mutel</Authors>
     <!-- Markdig.Wpf still supports net452, a target still supported by by Microsoft until January 10, 2023 -->
     <!-- see: https://github.com/xoofx/markdig/pull/466 -->
-    <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <PackageTags>Markdown CommonMark md html md2html</PackageTags>
     <PackageReleaseNotes>https://github.com/lunet-io/markdig/blob/master/changelog.md</PackageReleaseNotes>


### PR DESCRIPTION
This PR drops support for the netcoreapp3.1 target (now out of support).

.netcoreapp3.1 will get the netstandard2.1 target after this update.