### PR TITLE
Allow YAML front matter in the middle of the document

### DIFF
--- a/src/Markdig.Tests/TestYamlFrontMatterExtension.cs
+++ b/src/Markdig.Tests/TestYamlFrontMatterExtension.cs
@@ -18,6 +18,19 @@ public class TestYamlFrontMatterExtension
         Assert.That(markdownRenderer.ObjectRenderers.Contains<YamlFrontMatterRoundtripRenderer>(), Is.EqualTo(hasYamlFrontMatterRoundtripRenderer));
     }
 
+    [Test]
+    public void AllowYamlFrontMatterInMiddleOfDocument()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .Use(new YamlFrontMatterExtension { AllowInMiddleOfDocument = true })
+            .Build();
+
+        TestParser.TestSpec(
+            "This is a text1\n---\nthis: is a frontmatter\n---\nThis is a text2",
+            "<p>This is a text1</p>\n<p>This is a text2</p>",
+            pipeline);
+    }
+
     private static IEnumerable<TestCaseData> TestCases()
     {
         yield return new TestCaseData(new IMarkdownObjectRenderer[]

--- a/src/Markdig/Extensions/Yaml/YamlFrontMatterExtension.cs
+++ b/src/Markdig/Extensions/Yaml/YamlFrontMatterExtension.cs
@@ -12,12 +12,17 @@ namespace Markdig.Extensions.Yaml;
 /// </summary>
 public class YamlFrontMatterExtension : IMarkdownExtension
 {
+    /// <summary>
+    /// Allows the <see cref="YamlFrontMatterBlock"/> to appear in the middle of the markdown file.
+    /// </summary>
+    public bool AllowInMiddleOfDocument { get; set; }
+
     public void Setup(MarkdownPipelineBuilder pipeline)
     {
         if (!pipeline.BlockParsers.Contains<YamlFrontMatterParser>())
         {
             // Insert the YAML parser before the thematic break parser, as it is also triggered on a --- dash
-            pipeline.BlockParsers.InsertBefore<ThematicBreakParser>(new YamlFrontMatterParser());
+            pipeline.BlockParsers.InsertBefore<ThematicBreakParser>(new YamlFrontMatterParser { AllowInMiddleOfDocument = AllowInMiddleOfDocument });
         }
     }
 

--- a/src/Markdig/Extensions/Yaml/YamlFrontMatterParser.cs
+++ b/src/Markdig/Extensions/Yaml/YamlFrontMatterParser.cs
@@ -17,6 +17,11 @@ public class YamlFrontMatterParser : BlockParser
     // We reuse a FencedCodeBlock parser to grab a frontmatter, only active if it happens on the first line of the document.
 
     /// <summary>
+    /// Allows the <see cref="YamlFrontMatterBlock"/> to appear in the middle of the markdown file.
+    /// </summary>
+    public bool AllowInMiddleOfDocument { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="YamlFrontMatterParser"/> class.
     /// </summary>
     public YamlFrontMatterParser()
@@ -48,7 +53,7 @@ public class YamlFrontMatterParser : BlockParser
         }
 
         // Only accept a frontmatter at the beginning of the file
-        if (processor.Start != 0)
+        if (!AllowInMiddleOfDocument && processor.Start != 0)
         {
             return BlockState.None;
         }


### PR DESCRIPTION
This PR enables customizing the YAML front matter extension to allow it to appear in the middle of the markdown file.

The [docfx](https://github.com/dotnet/docfx) overwrite file feature leverage this feature to embed multiple YAML fragments in the same markdown file. With this change, docfx can be fully migrated to markdig.

Fixes: https://github.com/dotnet/docfx/issues/8441