### PR TITLE
Add relative path support for Audio and Video Urls to  MediaLinks Extension

### DIFF
--- a/src/Markdig.Tests/TestMediaLinks.cs
+++ b/src/Markdig.Tests/TestMediaLinks.cs
@@ -36,6 +36,16 @@ public class TestMediaLinks
         Assert.AreEqual(html, expected);
     }
 
+    [TestCase("![static video relative path](./video.mp4)",
+        "<p><video width=\"500\" height=\"281\" controls=\"\"><source type=\"video/mp4\" src=\"./video.mp4\"></source></video></p>\n")]
+    [TestCase("![static audio relative path](./audio.mp3)",
+        "<p><audio width=\"500\" controls=\"\"><source type=\"audio/mpeg\" src=\"./audio.mp3\"></source></audio></p>\n")]
+    public void TestBuiltInHostsWithRelativePaths(string markdown, string expected)
+    {
+        string html = Markdown.ToHtml(markdown, GetPipeline());
+        Assert.AreEqual(html, expected);
+    }
+    
     private class TestHostProvider : IHostProvider
     {
         public string Class { get; } = "regex";

--- a/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
+++ b/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
@@ -98,11 +98,9 @@ public class MediaLinkExtension : IMarkdownExtension
 
     private bool TryGuessAudioVideoFile(Uri uri, bool isSchemaRelative, HtmlRenderer renderer, LinkInline linkInline)
     {
-        string path;
-        if (uri.IsAbsoluteUri)
-            path = uri.GetComponents(UriComponents.Path, UriFormat.Unescaped);
-        else
-            path = uri.ToString();
+        string path = uri.IsAbsoluteUri
+            ? uri.GetComponents(UriComponents.Path, UriFormat.Unescaped)
+            : uri.ToString();
         
         // Otherwise try to detect if we have an audio/video from the file extension
         var lastDot = path.LastIndexOf('.');

--- a/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
+++ b/src/Markdig/Extensions/MediaLinks/MediaLinkExtension.cs
@@ -50,27 +50,32 @@ public class MediaLinkExtension : IMarkdownExtension
             return false;
         }
 
+        var url = linkInline.Url;
         bool isSchemaRelative = false;
-        // Only process absolute Uri
-        if (!Uri.TryCreate(linkInline.Url, UriKind.RelativeOrAbsolute, out Uri? uri) || !uri.IsAbsoluteUri)
+
+        // force // schema to an absolute url
+        if (url.StartsWith("//", StringComparison.Ordinal))
         {
-            // see https://tools.ietf.org/html/rfc3986#section-4.2
-            // since relative uri doesn't support many properties, "http" is used as a placeholder here.
-            if (linkInline.Url.StartsWith("//", StringComparison.Ordinal) && Uri.TryCreate("http:" + linkInline.Url, UriKind.Absolute, out uri))
+            url = "https:" + url;
+            isSchemaRelative = true;
+        }
+
+        // Make sure we have a valid absolute/relative url
+        if (!Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out Uri? uri)) // || !uri.IsAbsoluteUri)
+        {
+            return false;
+        }
+        
+        // iFrame has to be absolute path
+        if (uri.IsAbsoluteUri)
+        {
+            if (TryRenderIframeFromKnownProviders(uri, isSchemaRelative, renderer, linkInline))
             {
-                isSchemaRelative = true;
-            }
-            else
-            {
-                return false;
+                return true;
             }
         }
 
-        if (TryRenderIframeFromKnownProviders(uri, isSchemaRelative, renderer, linkInline))
-        {
-            return true;
-        }
-
+        // audio/video has can have relative path
         if (TryGuessAudioVideoFile(uri, isSchemaRelative, renderer, linkInline))
         {
             return true;
@@ -93,7 +98,12 @@ public class MediaLinkExtension : IMarkdownExtension
 
     private bool TryGuessAudioVideoFile(Uri uri, bool isSchemaRelative, HtmlRenderer renderer, LinkInline linkInline)
     {
-        var path = uri.GetComponents(UriComponents.Path, UriFormat.Unescaped);
+        string path;
+        if (uri.IsAbsoluteUri)
+            path = uri.GetComponents(UriComponents.Path, UriFormat.Unescaped);
+        else
+            path = uri.ToString();
+        
         // Otherwise try to detect if we have an audio/video from the file extension
         var lastDot = path.LastIndexOf('.');
         if (lastDot >= 0 &&

--- a/src/global.json
+++ b/src/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "6.0.100",
-    "rollForward": "latestMinor",
+    "rollForward": "latestMajor",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
Allow detect and embed relative URLs for image tag usage of audio and video links. Relates to #715.


Updated linking looks like this:

![image](https://github.com/xoofx/markdig/assets/1374013/9e91a948-ba90-4d89-8af4-124a9961e8d6)

Note relative links now work picking up media files out of the current folder as well as online links.