### PR TITLE
Make AllowNull internal to prevent conflicts

### DIFF
--- a/src/Markdig/Polyfills/NullableAttributes.cs
+++ b/src/Markdig/Polyfills/NullableAttributes.cs
@@ -17,7 +17,7 @@ internal sealed class NotNullWhenAttribute : Attribute
 }
 
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, Inherited = false)]
-public sealed class AllowNullAttribute : Attribute { }
+internal sealed class AllowNullAttribute : Attribute { }
 #endif
 
 #if !NET5_0_OR_GREATER


### PR DESCRIPTION
- Unity uses a version of "netstandard2.1", but already includes the AllowNull attribute
- This will prevent conflicts with other packages, that might include this attribute as well