### PR TITLE
Fix source span calculation

### DIFF
--- a/src/Markdig.Tests/MiscTests.cs
+++ b/src/Markdig.Tests/MiscTests.cs
@@ -1,7 +1,7 @@
 using System.Text.RegularExpressions;
 
 using Markdig.Extensions.AutoLinks;
-
+using Markdig.Syntax;
 using NUnit.Framework;
 
 namespace Markdig.Tests;
@@ -198,9 +198,9 @@ $$
 <div class=""math"">
 \begin{align}
 \sqrt{37} & = \sqrt{\frac{73^2-1}{12^2}} \\
- & = \sqrt{\frac{73^2}{12^2}\cdot\frac{73^2-1}{73^2}} \\ 
+ & = \sqrt{\frac{73^2}{12^2}\cdot\frac{73^2-1}{73^2}} \\
  & = \sqrt{\frac{73^2}{12^2}}\sqrt{\frac{73^2-1}{73^2}} \\
- & = \frac{73}{12}\sqrt{1 - \frac{1}{73^2}} \\ 
+ & = \frac{73}{12}\sqrt{1 - \frac{1}{73^2}} \\
  & \approx \frac{73}{12}\left(1 - \frac{1}{2\cdot73^2}\right)
 \end{align}
 </div>
@@ -290,5 +290,17 @@ $$
 
         TestParser.TestSpec("www.foo.bar", "<p><a href=\"http://www.foo.bar\">www.foo.bar</a></p>", pipeline);
         TestParser.TestSpec("www.foo.bar", "<p><a href=\"https://www.foo.bar\">www.foo.bar</a></p>", httpsPipeline);
+    }
+
+    [Test]
+    public void RootInlineHasCorrectSourceSpan()
+    {
+        var pipeline = new MarkdownPipelineBuilder().UsePreciseSourceLocation().Build();
+        pipeline.TrackTrivia = true;
+
+        var document = Markdown.Parse("0123456789\n", pipeline);
+
+        var expectedSourceSpan = new SourceSpan(0, 10);
+        Assert.That(((LeafBlock)document.LastChild).Inline.Span == expectedSourceSpan);
     }
 }

--- a/src/Markdig.Tests/MiscTests.cs
+++ b/src/Markdig.Tests/MiscTests.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 
 using Markdig.Extensions.AutoLinks;
+using Markdig.Extensions.Tables;
 using Markdig.Syntax;
 using NUnit.Framework;
 
@@ -302,5 +303,18 @@ $$
 
         var expectedSourceSpan = new SourceSpan(0, 10);
         Assert.That(((LeafBlock)document.LastChild).Inline.Span == expectedSourceSpan);
+    }
+
+    [Test]
+    public void RootInlineInTableCellHasCorrectSourceSpan()
+    {
+        var pipeline = new MarkdownPipelineBuilder().UsePreciseSourceLocation().UseAdvancedExtensions().Build();
+        pipeline.TrackTrivia = true;
+
+        var document = Markdown.Parse("| a | b |\n| --- | --- |\n| <span id=\"dest\"></span><span id=\"DEST\"></span>*dest*<br/> | \\[in\\] The address of the result of the operation.<br/> |", pipeline);
+
+        var paragraph = (ParagraphBlock)((TableCell)((TableRow)((Table)document.LastChild).LastChild).First()).LastChild;
+        Assert.That(paragraph.Inline.Span.Start == paragraph.Inline.FirstChild.Span.Start);
+        Assert.That(paragraph.Inline.Span.End == paragraph.Inline.LastChild.Span.End);
     }
 }

--- a/src/Markdig.Tests/TestSourcePosition.cs
+++ b/src/Markdig.Tests/TestSourcePosition.cs
@@ -68,6 +68,28 @@ literal      ( 2, 0) 12-21
     }
 
     [Test]
+    public void TestParagraphWithEndNewLine()
+    {
+        Check("0123456789\n", @"
+paragraph    ( 0, 0)  0-10
+literal      ( 0, 0)  0-9
+linebreak    ( 0,10) 10-10
+", trackTrivia: true);
+
+        Check("0123456789\r", @"
+paragraph    ( 0, 0)  0-10
+literal      ( 0, 0)  0-9
+linebreak    ( 0,10) 10-10
+", trackTrivia: true);
+
+        Check("0123456789\r\n", @"
+paragraph    ( 0, 0)  0-11
+literal      ( 0, 0)  0-9
+linebreak    ( 0,10) 10-11
+", trackTrivia: true);
+    }
+
+    [Test]
     public void TestEmphasis()
     {
         Check("012**3456789**", @"
@@ -825,9 +847,10 @@ literal      ( 8, 2) 77-92
 ");
     }
 
-    private static void Check(string text, string expectedResult, string extensions = null)
+    private static void Check(string text, string expectedResult, string extensions = null, bool trackTrivia = false)
     {
         var pipelineBuilder = new MarkdownPipelineBuilder().UsePreciseSourceLocation();
+        pipelineBuilder.TrackTrivia = trackTrivia;
         if (extensions != null)
         {
             pipelineBuilder.Configure(extensions);

--- a/src/Markdig/Extensions/Tables/PipeTableParser.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableParser.cs
@@ -443,6 +443,11 @@ public class PipeTableParser : InlineParser, IPostInlineProcessor
         {
             var paragraph = (ParagraphBlock) cell[0];
             state.PostProcessInlines(postInlineProcessorIndex + 1, paragraph.Inline, null, true);
+            if (paragraph.Inline?.LastChild is not null)
+            {
+                paragraph.Inline.Span.End = paragraph.Inline.LastChild.Span.End;
+                paragraph.UpdateSpanEnd(paragraph.Inline.LastChild.Span.End);
+            }
         }
 
         // Clear cells when we are done
@@ -520,7 +525,7 @@ public class PipeTableParser : InlineParser, IPostInlineProcessor
                 // Create aligns until we may have a header row
 
                 aligns ??= new List<TableColumnDefinition>();
-                
+
                 aligns.Add(new TableColumnDefinition() { Alignment =  align });
 
                 // If this is the last delimiter, we need to check the right side of the `|` delimiter

--- a/src/Markdig/Parsers/InlineProcessor.cs
+++ b/src/Markdig/Parsers/InlineProcessor.cs
@@ -225,6 +225,7 @@ public class InlineProcessor
         previousLineIndexForSliceOffset = 0;
         lineOffsets.Clear();
         var text = leafBlock.Lines.ToSlice(lineOffsets);
+        var textEnd = text.Length;
         leafBlock.Lines.Release();
         int previousStart = -1;
 
@@ -319,7 +320,8 @@ public class InlineProcessor
                 var newLine = leafBlock.NewLine;
                 if (newLine != NewLine.None)
                 {
-                    leafBlock.Inline.AppendChild(new LineBreakInline { NewLine = newLine });
+                    var position = GetSourcePosition(textEnd, out int line, out int column);
+                    leafBlock.Inline.AppendChild(new LineBreakInline { NewLine = newLine, Line = line, Column = column, Span = { Start = position, End = position + (newLine == NewLine.CarriageReturnLineFeed ? 1 : 0) } });
                 }
             }
         }
@@ -342,6 +344,13 @@ public class InlineProcessor
         //    DebugLog.WriteLine("** Dump after Emphasis:");
         //    leafBlock.Inline.DumpTo(DebugLog);
         //}
+
+        if (leafBlock.Inline.LastChild is not null)
+        {
+            leafBlock.Inline.Span.End = leafBlock.Inline.LastChild.Span.End;
+        }
+
+        leafBlock.UpdateSpanEnd(leafBlock.Inline.Span.End);
     }
 
     public void PostProcessInlines(int startingIndex, Inline? root, Inline? lastChild, bool isFinalProcessing)

--- a/src/Markdig/Parsers/InlineProcessor.cs
+++ b/src/Markdig/Parsers/InlineProcessor.cs
@@ -348,9 +348,8 @@ public class InlineProcessor
         if (leafBlock.Inline.LastChild is not null)
         {
             leafBlock.Inline.Span.End = leafBlock.Inline.LastChild.Span.End;
+            leafBlock.UpdateSpanEnd(leafBlock.Inline.Span.End);
         }
-
-        leafBlock.UpdateSpanEnd(leafBlock.Inline.Span.End);
     }
 
     public void PostProcessInlines(int startingIndex, Inline? root, Inline? lastChild, bool isFinalProcessing)


### PR DESCRIPTION
Update the LeafBlock.Inline source span after `PostProcessInlines` calls.

fixes #731, #730 and #702