### PR TITLE
Better literal delimiter content string slice

### DIFF
--- a/src/Markdig.Tests/TestEmphasisPlus.cs
+++ b/src/Markdig.Tests/TestEmphasisPlus.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
-// This file is licensed under the BSD-Clause 2 license. 
+// This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
+
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
 
 namespace Markdig.Tests;
 
@@ -17,5 +20,18 @@ public partial class TestEmphasisPlus
     public void NormalStrongNormal()
     {
         TestParser.TestSpec("normal ***Strong emphasis*** normal", "<p>normal <em><strong>Strong emphasis</strong></em> normal</p>", "");
+    }
+
+    [Test]
+    public void OpenEmphasisHasConvenientContentStringSlice()
+    {
+        var pipeline = new MarkdownPipelineBuilder().Build();
+
+        var document = Markdown.Parse("test*test", pipeline);
+
+        var emphasisDelimiterLiteral = (LiteralInline)((ParagraphBlock)document.LastChild).Inline.ElementAt(1);
+        Assert.That(emphasisDelimiterLiteral.Content.Text == "test*test");
+        Assert.That(emphasisDelimiterLiteral.Content.Start == 4);
+        Assert.That(emphasisDelimiterLiteral.Content.End == 4);
     }
 }

--- a/src/Markdig/Parsers/Inlines/EmphasisInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/EmphasisInlineParser.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
-// This file is licensed under the BSD-Clause 2 license. 
+// This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
 using System.Diagnostics;
@@ -109,7 +109,7 @@ public class EmphasisInlineParser : InlineParser, IPostInlineProcessor
         var child = container.FirstChild;
         while (child != null)
         {
-            // Stop the search on the delimitation child 
+            // Stop the search on the delimitation child
             if (child == lastChild)
             {
                 break;
@@ -197,7 +197,7 @@ public class EmphasisInlineParser : InlineParser, IPostInlineProcessor
             if (canOpen) delimiterType |= DelimiterType.Open;
             if (canClose) delimiterType |= DelimiterType.Close;
 
-            var delimiter = new EmphasisDelimiterInline(this, emphasisDesc)
+            var delimiter = new EmphasisDelimiterInline(this, emphasisDesc, new StringSlice(slice.Text, startPosition, slice.Start - 1))
             {
                 DelimiterCount = delimiterCount,
                 Type = delimiterType,
@@ -221,7 +221,7 @@ public class EmphasisInlineParser : InlineParser, IPostInlineProcessor
 
         // TODO: Benchmark difference between using List and LinkedList here since there could be a few Remove calls
 
-        // Move current_position forward in the delimiter stack (if needed) until 
+        // Move current_position forward in the delimiter stack (if needed) until
         // we find the first potential closer with delimiter * or _. (This will be the potential closer closest to the beginning of the input – the first one in parse order.)
         for (int i = 0; i < delimiters.Count; i++)
         {
@@ -237,7 +237,7 @@ public class EmphasisInlineParser : InlineParser, IPostInlineProcessor
             {
                 while (true)
                 {
-                    // Now, look back in the stack (staying above stack_bottom and the openers_bottom for this delimiter type) 
+                    // Now, look back in the stack (staying above stack_bottom and the openers_bottom for this delimiter type)
                     // for the first matching potential opener (“matching” means same delimiter).
                     EmphasisDelimiterInline? openDelimiter = null;
                     int openDelimiterIndex = -1;
@@ -307,8 +307,10 @@ public class EmphasisInlineParser : InlineParser, IPostInlineProcessor
                         emphasis.Column = openDelimiter.Column;
                         emphasis.Span.End = closeDelimiter.Span.End - closeDelimitercount + delimiterDelta;
 
+                        openDelimiter.Content.Start += delimiterDelta;
                         openDelimiter.Span.Start += delimiterDelta;
                         openDelimiter.Column += delimiterDelta;
+                        closeDelimiter.Content.Start += delimiterDelta;
                         closeDelimiter.Span.Start += delimiterDelta;
                         closeDelimiter.Column += delimiterDelta;
 
@@ -331,7 +333,7 @@ public class EmphasisInlineParser : InlineParser, IPostInlineProcessor
                         for (int k = i - 1; k >= openDelimiterIndex + 1; k--)
                         {
                             var literalDelimiter = delimiters[k];
-                            literalDelimiter.ReplaceBy(literalDelimiter.AsLiteralInline());                                
+                            literalDelimiter.ReplaceBy(literalDelimiter.AsLiteralInline());
                             delimiters.RemoveAt(k);
                             i--;
                         }

--- a/src/Markdig/Syntax/Inlines/EmphasisDelimiterInline.cs
+++ b/src/Markdig/Syntax/Inlines/EmphasisDelimiterInline.cs
@@ -30,6 +30,13 @@ public class EmphasisDelimiterInline : DelimiterInline
         Content = new StringSlice(ToLiteral());
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmphasisDelimiterInline" /> class.
+    /// </summary>
+    /// <param name="parser">The parser.</param>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <param name="content">The content.</param>
+    /// <exception cref="ArgumentNullException"></exception>
     internal EmphasisDelimiterInline(InlineParser parser, EmphasisDescriptor descriptor, StringSlice content) : base(parser)
     {
         if (descriptor is null)

--- a/src/Markdig/Syntax/Inlines/EmphasisDelimiterInline.cs
+++ b/src/Markdig/Syntax/Inlines/EmphasisDelimiterInline.cs
@@ -27,6 +27,7 @@ public class EmphasisDelimiterInline : DelimiterInline
 
         Descriptor = descriptor;
         DelimiterChar = descriptor.Character;
+        Content = new StringSlice(ToLiteral());
     }
 
     internal EmphasisDelimiterInline(InlineParser parser, EmphasisDescriptor descriptor, StringSlice content) : base(parser)

--- a/src/Markdig/Syntax/Inlines/EmphasisDelimiterInline.cs
+++ b/src/Markdig/Syntax/Inlines/EmphasisDelimiterInline.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
-// This file is licensed under the BSD-Clause 2 license. 
+// This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
 using Markdig.Helpers;
@@ -29,6 +29,16 @@ public class EmphasisDelimiterInline : DelimiterInline
         DelimiterChar = descriptor.Character;
     }
 
+    internal EmphasisDelimiterInline(InlineParser parser, EmphasisDescriptor descriptor, StringSlice content) : base(parser)
+    {
+        if (descriptor is null)
+            ThrowHelper.ArgumentNullException(nameof(descriptor));
+
+        Descriptor = descriptor;
+        DelimiterChar = descriptor.Character;
+        Content = content;
+    }
+
     /// <summary>
     /// Gets the descriptor for this emphasis.
     /// </summary>
@@ -44,6 +54,11 @@ public class EmphasisDelimiterInline : DelimiterInline
     /// </summary>
     public int DelimiterCount { get; set; }
 
+    /// <summary>
+    /// The content as a <see cref="StringSlice"/>.
+    /// </summary>
+    public StringSlice Content;
+
     public override string ToLiteral()
     {
         return DelimiterCount > 0 ? new string(DelimiterChar, DelimiterCount) : string.Empty;
@@ -53,7 +68,7 @@ public class EmphasisDelimiterInline : DelimiterInline
     {
         return new LiteralInline()
         {
-            Content = new StringSlice(ToLiteral()),
+            Content = Content,
             IsClosed = true,
             Span = Span,
             Line = Line,


### PR DESCRIPTION
Instead of creating a new StringSlice only containing the delimiter chars, use the provided StringSlice from the match method with an appropriate start and end index.

Marked as draft until it is clear if this change is desired.

Fixes: #735 