### PR TITLE
.NET 8.0 and a few other perf improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,13 @@ jobs:
         submodules: true
         fetch-depth: 0
 
-    - name: Install .NET 8.0
+    - name: Install .NET 6.0, 7.0, and 8.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: |
+          6.0.x
+          7.0.x
+          8.0.x
 
     - name: Build, Test, Pack, Publish
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
         submodules: true
         fetch-depth: 0
 
-    - name: Install .NET 6.0
+    - name: Install .NET 8.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '8.0.x'
 
     - name: Build, Test, Pack, Publish
       shell: bash

--- a/src/Markdig.Tests/Markdig.Tests.csproj
+++ b/src/Markdig.Tests/Markdig.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Markdig.Tests/TestYamlFrontMatterExtension.cs
+++ b/src/Markdig.Tests/TestYamlFrontMatterExtension.cs
@@ -75,8 +75,11 @@ public class TestYamlFrontMatterExtension
             ObjectRenderers = new ObjectRendererCollection();
         }
 
+#pragma warning disable CS0067 // ObjectWriteBefore/ObjectWriteAfter is never used
         public event Action<IMarkdownRenderer, MarkdownObject> ObjectWriteBefore;
         public event Action<IMarkdownRenderer, MarkdownObject> ObjectWriteAfter;
+#pragma warning restore CS0067
+
         public ObjectRendererCollection ObjectRenderers { get; }
         public object Render(MarkdownObject markdownObject)
         {

--- a/src/Markdig/Helpers/BlockWrapper.cs
+++ b/src/Markdig/Helpers/BlockWrapper.cs
@@ -22,7 +22,7 @@ internal readonly struct BlockWrapper : IEquatable<BlockWrapper>
 
     public bool Equals(BlockWrapper other) => ReferenceEquals(Block, other.Block);
 
-    public override bool Equals(object obj) => Block.Equals(obj);
+    public override bool Equals(object? obj) => Block.Equals(obj);
 
     public override int GetHashCode() => Block.GetHashCode();
 }

--- a/src/Markdig/Helpers/CharacterMap.cs
+++ b/src/Markdig/Helpers/CharacterMap.cs
@@ -2,14 +2,10 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
-#if NETCOREAPP3_1_OR_GREATER
-using System.Numerics;
-using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
-#endif
 
 namespace Markdig.Helpers;
 
@@ -19,13 +15,9 @@ namespace Markdig.Helpers;
 /// <typeparam name="T"></typeparam>
 public sealed class CharacterMap<T> where T : class
 {
-#if NETCOREAPP3_1_OR_GREATER
-    private readonly Vector128<byte> _asciiBitmap;
-#endif
-
-    private readonly T[] asciiMap;
-    private readonly Dictionary<uint, T>? nonAsciiMap;
-    private readonly BoolVector128 isOpeningCharacter;
+    private readonly SearchValues<char> _values;
+    private readonly T[] _asciiMap;
+    private readonly Dictionary<uint, T>? _nonAsciiMap;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CharacterMap{T}"/> class.
@@ -35,64 +27,38 @@ public sealed class CharacterMap<T> where T : class
     public CharacterMap(IEnumerable<KeyValuePair<char, T>> maps)
     {
         if (maps is null) ThrowHelper.ArgumentNullException(nameof(maps));
+
         var charSet = new HashSet<char>();
-        int maxChar = 0;
 
         foreach (var map in maps)
         {
-            var openingChar = map.Key;
-            charSet.Add(openingChar);
-
-            if (openingChar < 128)
-            {
-                maxChar = Math.Max(maxChar, openingChar);
-
-                if (openingChar == 0)
-                {
-                    ThrowHelper.ArgumentOutOfRangeException("Null is not a valid opening character.", nameof(maps));
-                }
-            }
-            else
-            {
-                nonAsciiMap ??= new Dictionary<uint, T>();
-            }
+            charSet.Add(map.Key);
         }
 
         OpeningCharacters = charSet.ToArray();
         Array.Sort(OpeningCharacters);
 
-        asciiMap = new T[maxChar + 1];
+        _asciiMap = new T[128];
 
         foreach (var state in maps)
         {
             char openingChar = state.Key;
             if (openingChar < 128)
             {
-                asciiMap[openingChar] ??= state.Value;
-                isOpeningCharacter.Set(openingChar);
+                _asciiMap[openingChar] ??= state.Value;
             }
-            else if (!nonAsciiMap!.ContainsKey(openingChar))
+            else
             {
-                nonAsciiMap[openingChar] = state.Value;
+                _nonAsciiMap ??= new Dictionary<uint, T>();
+
+                if (!_nonAsciiMap.ContainsKey(openingChar))
+                {
+                    _nonAsciiMap[openingChar] = state.Value;
+                }
             }
         }
 
-#if NETCOREAPP3_1_OR_GREATER
-        if (nonAsciiMap is null)
-        {
-            long bitmap_0_3 = 0;
-            long bitmap_4_7 = 0;
-
-            foreach (char openingChar in OpeningCharacters)
-            {
-                int position = (openingChar >> 4) | ((openingChar & 0x0F) << 3);
-                if (position < 64) bitmap_0_3 |= 1L << position;
-                else bitmap_4_7 |= 1L << (position - 64);
-            }
-
-            _asciiBitmap = Vector128.Create(bitmap_0_3, bitmap_4_7).AsByte();
-        }
-#endif
+        _values = SearchValues.Create(OpeningCharacters);
     }
 
     /// <summary>
@@ -110,7 +76,7 @@ public sealed class CharacterMap<T> where T : class
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
-            T[] asciiMap = this.asciiMap;
+            T[] asciiMap = _asciiMap;
             if (openingChar < (uint)asciiMap.Length)
             {
                 return asciiMap[openingChar];
@@ -118,12 +84,11 @@ public sealed class CharacterMap<T> where T : class
             else
             {
                 T? map = null;
-                nonAsciiMap?.TryGetValue(openingChar, out map);
+                _nonAsciiMap?.TryGetValue(openingChar, out map);
                 return map;
             }
         }
     }
-
 
     /// <summary>
     /// Searches for an opening character from a registered parser in the specified string.
@@ -132,167 +97,20 @@ public sealed class CharacterMap<T> where T : class
     /// <param name="start">The start.</param>
     /// <param name="end">The end.</param>
     /// <returns>Index position within the string of the first opening character found in the specified text; if not found, returns -1</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int IndexOfOpeningCharacter(string text, int start, int end)
     {
         Debug.Assert(text is not null);
-        Debug.Assert(start >= 0 && end >= 0);
-        Debug.Assert(end - start + 1 >= 0);
-        Debug.Assert(end - start + 1 <= text.Length);
 
-        if (nonAsciiMap is null)
+        ReadOnlySpan<char> span = text.AsSpan(start, end - start + 1);
+
+        int index = span.IndexOfAny(_values);
+
+        if (index >= 0)
         {
-#if NETCOREAPP3_1_OR_GREATER
-            if (Ssse3.IsSupported && BitConverter.IsLittleEndian)
-            {
-                // Based on http://0x80.pl/articles/simd-byte-lookup.html#universal-algorithm
-                // Optimized for sets in the [1, 127] range
-
-                int lengthMinusOne = end - start;
-                int charsToProcessVectorized = lengthMinusOne & ~(2 * Vector128<short>.Count - 1);
-                int finalStart = start + charsToProcessVectorized;
-
-                if (start < finalStart)
-                {
-                    ref char textStartRef = ref Unsafe.Add(ref Unsafe.AsRef(in text.GetPinnableReference()), start);
-                    Vector128<byte> bitmap = _asciiBitmap;
-                    do
-                    {
-                        // Load 32 bytes (16 chars) into two Vector128<short>s (chars)
-                        // Drop the high byte of each char
-                        // Pack the remaining bytes into a single Vector128<byte>
-                        Vector128<byte> input = Sse2.PackUnsignedSaturate(
-                            Unsafe.ReadUnaligned<Vector128<short>>(ref Unsafe.As<char, byte>(ref textStartRef)),
-                            Unsafe.ReadUnaligned<Vector128<short>>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref textStartRef, Vector128<short>.Count))));
-
-                        // Extract the higher nibble of each character ((input >> 4) & 0xF)
-                        Vector128<byte> higherNibbles = Sse2.And(Sse2.ShiftRightLogical(input.AsUInt16(), 4).AsByte(), Vector128.Create((byte)0xF));
-
-                        // Lookup the matching higher nibble for each character based on the lower nibble
-                        // PSHUFB will set the result to 0 for any non-ASCII (> 127) character
-                        Vector128<byte> bitsets = Ssse3.Shuffle(bitmap, input);
-
-                        // Calculate a bitmask (1 << (higherNibble % 8)) for each character
-                        Vector128<byte> bitmask = Ssse3.Shuffle(Vector128.Create(0x8040201008040201).AsByte(), higherNibbles);
-
-                        // Check which characters are present in the set
-                        // We are relying on bitsets being zero for non-ASCII characters
-                        Vector128<byte> result = Sse2.And(bitsets, bitmask);
-
-                        if (!result.Equals(Vector128<byte>.Zero))
-                        {
-                            int resultMask = ~Sse2.MoveMask(Sse2.CompareEqual(result, Vector128<byte>.Zero));
-                            return start + BitOperations.TrailingZeroCount((uint)resultMask);
-                        }
-
-                        start += 2 * Vector128<short>.Count;
-                        textStartRef = ref Unsafe.Add(ref textStartRef, 2 * Vector128<short>.Count);
-                    }
-                    while (start != finalStart);
-                }
-            }
-
-            ref char textRef = ref Unsafe.AsRef(in text.GetPinnableReference());
-            for (; start <= end; start++)
-            {
-                if (IntPtr.Size == 4)
-                {
-                    uint c = Unsafe.Add(ref textRef, start);
-                    if (c < 128 && isOpeningCharacter[c])
-                    {
-                        return start;
-                    }
-                }
-                else
-                {
-                    ulong c = Unsafe.Add(ref textRef, start);
-                    if (c < 128 && isOpeningCharacter[c])
-                    {
-                        return start;
-                    }
-                }
-            }
-#else
-            unsafe
-            {
-                fixed (char* pText = text)
-                {
-                    for (int i = start; i <= end; i++)
-                    {
-                        char c = pText[i];
-                        if (c < 128 && isOpeningCharacter[c])
-                        {
-                            return i;
-                        }
-                    }
-                }
-            }
-#endif
-            return -1;
+            index += start;
         }
-        else
-        {
-            return IndexOfOpeningCharacterNonAscii(text, start, end);
-        }
-    }
 
-    private int IndexOfOpeningCharacterNonAscii(string text, int start, int end)
-    {
-#if NETCOREAPP3_1_OR_GREATER
-        ref char textRef = ref Unsafe.AsRef(in text.GetPinnableReference());
-        for (int i = start; i <= end; i++)
-        {
-            char c = Unsafe.Add(ref textRef, i);
-            if (c < 128 ? isOpeningCharacter[c] : nonAsciiMap!.ContainsKey(c))
-            {
-                return i;
-            }
-        }
-#else
-        unsafe
-        {
-            fixed (char* pText = text)
-            {
-                for (int i = start; i <= end; i++)
-                {
-                    char c = pText[i];
-                    if (c < 128 ? isOpeningCharacter[c] : nonAsciiMap!.ContainsKey(c))
-                    {
-                        return i;
-                    }
-                }
-            }
-        }
-#endif
-        return -1;
-    }
-}
-
-internal unsafe struct BoolVector128
-{
-    private fixed bool values[128];
-
-    public void Set(char c)
-    {
-        Debug.Assert(c < 128);
-        values[c] = true;
-    }
-
-    public readonly bool this[uint c]
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get
-        {
-            Debug.Assert(c < 128);
-            return values[c];
-        }
-    }
-    public readonly bool this[ulong c]
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get
-        {
-            Debug.Assert(c < 128 && IntPtr.Size == 8);
-            return values[c];
-        }
+        return index;
     }
 }

--- a/src/Markdig/Helpers/FastStringWriter.cs
+++ b/src/Markdig/Helpers/FastStringWriter.cs
@@ -278,8 +278,7 @@ internal sealed class FastStringWriter : TextWriter
         _pos = 0;
     }
 
-    public override string ToString()
-    {
-        return _chars.AsSpan(0, _pos).ToString();
-    }
+    public override string ToString() => AsSpan().ToString();
+
+    public ReadOnlySpan<char> AsSpan() => _chars.AsSpan(0, _pos);
 }

--- a/src/Markdig/Helpers/HexConverter.cs
+++ b/src/Markdig/Helpers/HexConverter.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace Markdig.Helpers;
+
+// Based on https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/HexConverter.cs
+internal static class HexConverter
+{
+    public enum Casing : uint
+    {
+        Upper = 0,
+        Lower = 0x2020U,
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ToCharsBuffer(byte value, Span<char> buffer, int startingIndex = 0, Casing casing = Casing.Upper)
+    {
+        uint difference = (((uint)value & 0xF0U) << 4) + ((uint)value & 0x0FU) - 0x8989U;
+        uint packedResult = ((((uint)(-(int)difference) & 0x7070U) >> 4) + difference + 0xB9B9U) | (uint)casing;
+
+        buffer[startingIndex + 1] = (char)(packedResult & 0xFF);
+        buffer[startingIndex] = (char)(packedResult >> 8);
+    }
+}

--- a/src/Markdig/Helpers/LineReader.cs
+++ b/src/Markdig/Helpers/LineReader.cs
@@ -53,7 +53,7 @@ public struct LineReader
         else
         {
 #if NETCOREAPP3_1_OR_GREATER
-            ReadOnlySpan<char> span = MemoryMarshal.CreateReadOnlySpan(ref Unsafe.Add(ref Unsafe.AsRef(text.GetPinnableReference()), sourcePosition), end - sourcePosition);
+            ReadOnlySpan<char> span = MemoryMarshal.CreateReadOnlySpan(ref Unsafe.Add(ref Unsafe.AsRef(in text.GetPinnableReference()), sourcePosition), end - sourcePosition);
 #else
             ReadOnlySpan<char> span = text.AsSpan(sourcePosition);
 #endif
@@ -65,7 +65,7 @@ public struct LineReader
                 newSourcePosition = end + 1;
 
 #if NETCOREAPP3_1_OR_GREATER
-                if (Unsafe.Add(ref Unsafe.AsRef(text.GetPinnableReference()), end) == '\r')
+                if (Unsafe.Add(ref Unsafe.AsRef(in text.GetPinnableReference()), end) == '\r')
 #else
                 if ((uint)end < (uint)text.Length && text[end] == '\r')
 #endif

--- a/src/Markdig/Helpers/LinkHelper.cs
+++ b/src/Markdig/Helpers/LinkHelper.cs
@@ -20,6 +20,11 @@ public static class LinkHelper
 
     public static string Urilize(string headingText, bool allowOnlyAscii, bool keepOpeningDigits = false)
     {
+        return Urilize(headingText.AsSpan(), allowOnlyAscii, keepOpeningDigits);
+    }
+
+    public static string Urilize(ReadOnlySpan<char> headingText, bool allowOnlyAscii, bool keepOpeningDigits = false)
+    {
         var headingBuffer = new ValueStringBuilder(stackalloc char[ValueStringBuilder.StackallocThreshold]);
         bool hasLetter = keepOpeningDigits && headingText.Length > 0 && char.IsLetterOrDigit(headingText[0]);
         bool previousIsSpace = false;
@@ -96,14 +101,23 @@ public static class LinkHelper
 
     public static string UrilizeAsGfm(string headingText)
     {
+        return UrilizeAsGfm(headingText.AsSpan());
+    }
+
+    public static string UrilizeAsGfm(ReadOnlySpan<char> headingText)
+    {
         // Following https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/toc_filter.rb
         var headingBuffer = new ValueStringBuilder(stackalloc char[ValueStringBuilder.StackallocThreshold]);
         for (int i = 0; i < headingText.Length; i++)
         {
             var c = headingText[i];
-            if (char.IsLetterOrDigit(c) || c == ' ' || c == '-' || c == '_')
+            if (char.IsLetterOrDigit(c) || c == '-' || c == '_')
             {
-                headingBuffer.Append(c == ' ' ? '-' : char.ToLowerInvariant(c));
+                headingBuffer.Append(char.ToLowerInvariant(c));
+            }
+            else if (c == ' ')
+            {
+                headingBuffer.Append('-');
             }
         }
         return headingBuffer.ToString();

--- a/src/Markdig/Helpers/ObjectCache.cs
+++ b/src/Markdig/Helpers/ObjectCache.cs
@@ -36,7 +36,7 @@ public abstract class ObjectCache<T> where T : class
     /// <returns></returns>
     public T Get()
     {
-        if (_builders.TryDequeue(out T instance))
+        if (_builders.TryDequeue(out T? instance))
         {
             return instance;
         }

--- a/src/Markdig/Helpers/StringSlice.cs
+++ b/src/Markdig/Helpers/StringSlice.cs
@@ -475,7 +475,7 @@ public struct StringSlice : ICharIterator
         }
 
 #if NETCOREAPP3_1_OR_GREATER
-        return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.Add(ref Unsafe.AsRef(text.GetPinnableReference()), start), length);
+        return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.Add(ref Unsafe.AsRef(in text.GetPinnableReference()), start), length);
 #else
         return text.AsSpan(start, length);
 #endif

--- a/src/Markdig/Markdig.targets
+++ b/src/Markdig/Markdig.targets
@@ -5,7 +5,7 @@
     <Copyright>Alexandre Mutel</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Authors>Alexandre Mutel</Authors>
-    <TargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <PackageTags>Markdown CommonMark md html md2html</PackageTags>
     <PackageReleaseNotes>https://github.com/lunet-io/markdig/blob/master/changelog.md</PackageReleaseNotes>
@@ -14,7 +14,7 @@
     <PackageIcon>markdig.png</PackageIcon>
     <PackageProjectUrl>https://github.com/lunet-io/markdig</PackageProjectUrl>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>10</LangVersion>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Markdig/Markdown.cs
+++ b/src/Markdig/Markdown.cs
@@ -19,16 +19,10 @@ namespace Markdig;
 /// </summary>
 public static class Markdown
 {
-    public static string Version
-    {
-        get
-        {
-            if (_Version == null)
-                _Version = ((AssemblyFileVersionAttribute)typeof(Markdown).Assembly.GetCustomAttributes(typeof(AssemblyFileVersionAttribute), false).FirstOrDefault())?.Version ?? "Unknown";
-            return _Version;
-        }
-    }
-    private static string? _Version;
+    public static string Version =>
+        s_version ??= typeof(Markdown).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version ?? "Unknown";
+
+    private static string? s_version;
 
     internal static readonly MarkdownPipeline DefaultPipeline = new MarkdownPipelineBuilder().Build();
     private static readonly MarkdownPipeline _defaultTrackTriviaPipeline = new MarkdownPipelineBuilder().EnableTrackTrivia().Build();

--- a/src/Markdig/Parsers/Inlines/LiteralInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LiteralInlineParser.cs
@@ -32,14 +32,12 @@ public sealed class LiteralInlineParser : InlineParser
 
     public override bool Match(InlineProcessor processor, ref StringSlice slice)
     {
-        var text = slice.Text;
+        string text = slice.Text;
 
-        var startPosition = processor.GetSourcePosition(slice.Start, out int line, out int column);
-
-        var nextStart = processor.Parsers.IndexOfOpeningCharacter(text, slice.Start + 1, slice.End);
+        int nextStart = processor.Parsers.IndexOfOpeningCharacter(text, slice.Start + 1, slice.End);
         int length;
 
-        if (nextStart < 0)
+        if ((uint)nextStart >= (uint)text.Length)
         {
             nextStart = slice.End + 1;
             length = nextStart - slice.Start;
@@ -48,10 +46,10 @@ public sealed class LiteralInlineParser : InlineParser
         {
             // Remove line endings if the next char is a new line
             length = nextStart - slice.Start;
+
             if (!processor.TrackTrivia)
             {
-                var nextText = text[nextStart];
-                if (nextText == '\n' || nextText == '\r')
+                if (text[nextStart] is '\n' or '\r')
                 {
                     int end = nextStart - 1;
                     while (length > 0 && text[end].IsSpace())
@@ -84,7 +82,7 @@ public sealed class LiteralInlineParser : InlineParser
                 processor.Inline = new LiteralInline
                 {
                     Content = length > 0 ? newSlice : StringSlice.Empty,
-                    Span = new SourceSpan(startPosition, processor.GetSourcePosition(endPosition)),
+                    Span = new SourceSpan(processor.GetSourcePosition(slice.Start, out int line, out int column), processor.GetSourcePosition(endPosition)),
                     Line = line,
                     Column = column,
                 };

--- a/src/Markdig/Parsers/Inlines/LiteralInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LiteralInlineParser.cs
@@ -36,9 +36,7 @@ public sealed class LiteralInlineParser : InlineParser
 
         var startPosition = processor.GetSourcePosition(slice.Start, out int line, out int column);
 
-        // Slightly faster to perform our own search for opening characters
         var nextStart = processor.Parsers.IndexOfOpeningCharacter(text, slice.Start + 1, slice.End);
-        //var nextStart = str.IndexOfAny(processor.SpecialCharacters, slice.Start + 1, slice.Length - 1);
         int length;
 
         if (nextStart < 0)

--- a/src/Markdig/Polyfills/Ascii.cs
+++ b/src/Markdig/Polyfills/Ascii.cs
@@ -4,7 +4,7 @@
 
 #if !NET8_0_OR_GREATER
 
-namespace System;
+namespace System.Text;
 
 internal static class Ascii
 {

--- a/src/Markdig/Polyfills/Ascii.cs
+++ b/src/Markdig/Polyfills/Ascii.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+#if !NET8_0_OR_GREATER
+
+namespace System;
+
+internal static class Ascii
+{
+    public static bool IsValid(this string value)
+    {
+        return IsValid(value.AsSpan());
+    }
+
+    public static bool IsValid(this ReadOnlySpan<char> value)
+    {
+        for (int i = 0; i < value.Length; i++)
+        {
+            if (value[i] > 127)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+#endif

--- a/src/Markdig/Polyfills/EncodingExtensions.cs
+++ b/src/Markdig/Polyfills/EncodingExtensions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+#if !NETSTANDARD2_1_OR_GREATER
+
+using System.Runtime.InteropServices;
+
+namespace System.Text;
+
+internal static class EncodingExtensions
+{
+    public static unsafe int GetBytes(this Encoding encoding, ReadOnlySpan<char> chars, Span<byte> bytes)
+    {
+        fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
+        {
+            fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
+            {
+                return encoding.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
+            }
+        }
+    }
+}
+#endif

--- a/src/Markdig/Polyfills/IndexOfHelpers.cs
+++ b/src/Markdig/Polyfills/IndexOfHelpers.cs
@@ -21,6 +21,26 @@ internal static class IndexOfHelpers
 
         return false;
     }
+
+#if !NETSTANDARD2_1_OR_GREATER
+    public static int IndexOfAny(this ReadOnlySpan<char> span, string values)
+    {
+        for (int i = 0; i < span.Length; i++)
+        {
+            char c = span[i];
+
+            foreach (char v in values)
+            {
+                if (c == v)
+                {
+                    return i;
+                }
+            }
+        }
+
+        return -1;
+    }
+#endif
 }
 
 #endif

--- a/src/Markdig/Polyfills/IndexOfHelpers.cs
+++ b/src/Markdig/Polyfills/IndexOfHelpers.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+#if !NET8_0_OR_GREATER
+
+namespace System;
+
+internal static class IndexOfHelpers
+{
+    public static bool ContainsAnyExcept(this ReadOnlySpan<char> span, char value0, char value1, char value2)
+    {
+        for (int i = 0; i < span.Length; i++)
+        {
+            char c = span[i];
+            if (c != value0 && c != value1 && c != value2)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+#endif

--- a/src/Markdig/Polyfills/SearchValues.cs
+++ b/src/Markdig/Polyfills/SearchValues.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+#if !NET8_0_OR_GREATER
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Buffers;
+
+internal static class SearchValues
+{
+    public static SearchValues<char> Create(ReadOnlySpan<char> values)
+    {
+        return new PreNet8CompatSearchValues(values);
+    }
+
+    public static int IndexOfAny(this ReadOnlySpan<char> span, SearchValues<char> values)
+    {
+        return values.IndexOfAny(span);
+    }
+
+    public static int IndexOfAny(this Span<char> span, SearchValues<char> values)
+    {
+        return values.IndexOfAny(span);
+    }
+}
+
+internal abstract class SearchValues<T>
+{
+    public abstract int IndexOfAny(ReadOnlySpan<char> span);
+}
+
+internal sealed class PreNet8CompatSearchValues : SearchValues<char>
+{
+    private readonly BoolVector128 _ascii;
+    private readonly HashSet<char>? _nonAscii;
+
+    public PreNet8CompatSearchValues(ReadOnlySpan<char> values)
+    {
+        foreach (char c in values)
+        {
+            if (c < 128)
+            {
+                _ascii.Set(c);
+            }
+            else
+            {
+                _nonAscii ??= new HashSet<char>();
+                _nonAscii.Add(c);
+            }
+        }
+    }
+
+    public override int IndexOfAny(ReadOnlySpan<char> span)
+    {
+        if (_nonAscii is null)
+        {
+            for (int i = 0; i < span.Length; i++)
+            {
+                char c = span[i];
+
+                if (c < 128 && _ascii[c])
+                {
+                    return i;
+                }
+            }
+        }
+        else
+        {
+            for (int i = 0; i < span.Length; i++)
+            {
+                char c = span[i];
+
+                if (c < 128 ? _ascii[c] : _nonAscii.Contains(c))
+                {
+                    return i;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    private unsafe struct BoolVector128
+    {
+        private fixed bool _values[128];
+
+        public void Set(char c)
+        {
+            Debug.Assert(c < 128);
+            _values[c] = true;
+        }
+
+        public readonly bool this[uint c]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                Debug.Assert(c < 128);
+                return _values[c];
+            }
+        }
+    }
+}
+
+#endif

--- a/src/Markdig/Syntax/Inlines/ContainerInline.cs
+++ b/src/Markdig/Syntax/Inlines/ContainerInline.cs
@@ -16,7 +16,7 @@ namespace Markdig.Syntax.Inlines;
 /// <seealso cref="Inline" />
 public class ContainerInline : Inline, IEnumerable<Inline>
 {
-    public ContainerInline()
+    public ContainerInline() : base(dummySkipTypeKind: true)
     {
         SetTypeKind(isInline: true, isContainer: true);
     }

--- a/src/Markdig/Syntax/Inlines/EmphasisDelimiterInline.cs
+++ b/src/Markdig/Syntax/Inlines/EmphasisDelimiterInline.cs
@@ -69,7 +69,21 @@ public class EmphasisDelimiterInline : DelimiterInline
 
     public override string ToLiteral()
     {
-        return DelimiterCount > 0 ? new string(DelimiterChar, DelimiterCount) : string.Empty;
+        if (DelimiterCount == 1)
+        {
+            return DelimiterChar switch
+            {
+                '*' => "*",
+                '_' => "_",
+                '~' => "~",
+                '^' => "^",
+                '+' => "+",
+                '=' => "=",
+                _ => DelimiterChar.ToString()
+            };
+        }
+
+        return new string(DelimiterChar, DelimiterCount);
     }
 
     public LiteralInline AsLiteralInline()

--- a/src/Markdig/Syntax/Inlines/Inline.cs
+++ b/src/Markdig/Syntax/Inlines/Inline.cs
@@ -20,6 +20,8 @@ public abstract class Inline : MarkdownObject, IInline
         SetTypeKind(isInline: true, isContainer: false);
     }
 
+    private protected Inline(bool dummySkipTypeKind) { }
+
     /// <summary>
     /// Gets the parent container of this inline.
     /// </summary>

--- a/src/Markdig/Syntax/MarkdownObject.cs
+++ b/src/Markdig/Syntax/MarkdownObject.cs
@@ -2,6 +2,7 @@
 // This file is licensed under the BSD-Clause 2 license. 
 // See the license.txt file in the project root for more information.
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 using Markdig.Helpers;
@@ -36,7 +37,8 @@ public abstract class MarkdownObject : IMarkdownObject
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private protected void SetTypeKind(bool isInline, bool isContainer)
     {
-        _lineBits |= (isInline ? IsInlineMask : 0) | (isContainer ? IsContainerMask : 0);
+        Debug.Assert(_lineBits == 0);
+        _lineBits = (isInline ? IsInlineMask : 0) | (isContainer ? IsContainerMask : 0);
     }
 
     private protected bool IsClosedInternal

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "8.0.100",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }


### PR DESCRIPTION
- Added a .NET 8.0 TFM
- Polyfills for a few new functionalities (`Ascii`, `SearchValues`, `ContainsAnyExcept` ...)
- Replaced the `CharacterMap.IndexOfOpeningCharacter` implementation with a call to `IndexOfAny(SearchValues)`
  - Don't need manual vectorization code in Markdig for this anymore
  - Also get AVX2 paths and ARM64 acceleration "for free"
- Changed `CodeInlineParser.Match` to make use of vectorized helpers
- Sped up `WriteEscape` & `WriteEscapeUrl` rendering (vectorized scanning via SearchValues)
- A few random alloc / codegen improvements

A few rough numbers from parsing a large markdown document with precise source locations (.NET 8 perf improvements blogpost).
Both `main` and `pr` numbers are from 8.0

| Method         | Job  | Mean       | Error    | Ratio |
|--------------- |----- |-----------:|---------:|------:|
| Parse          | main | 2,762.2 us | 13.73 us |  1.00 |
| Parse          | pr   | 2,509.3 us | 13.97 us |  0.91 |
|                |      |            |          |       |
| ParseAdvanced  | main | 7,991.8 us | 49.89 us |  1.00 |
| ParseAdvanced  | pr   | 7,758.2 us | 48.96 us |  0.97 |
|                |      |            |          |       |
| Render         | main |   954.6 us |  3.39 us |  1.00 |
| Render         | pr   |   710.6 us |  2.42 us |  0.74 |
|                |      |            |          |       |
| RenderAdvanced | main | 1,301.3 us |  4.76 us |  1.00 |
| RenderAdvanced | pr   | 1,068.6 us | 20.04 us |  0.82 |

<details>
<summary>Including 7.0 vs 8.0 comparison</summary>

| Method         | Job  | Runtime  | Mean       | Error    | Ratio |
|--------------- |----- |--------- |-----------:|---------:|------:|
| Parse          | main | .NET 7.0 | 3,125.7 us | 18.30 us |  1.00 |
| Parse          | pr   | .NET 8.0 | 2,486.9 us |  9.08 us |  0.80 |
|                |      |          |            |          |       |
| ParseAdvanced  | main | .NET 7.0 | 8,481.4 us | 35.35 us |  1.00 |
| ParseAdvanced  | pr   | .NET 8.0 | 7,682.9 us | 17.01 us |  0.91 |
|                |      |          |            |          |       |
| Render         | main | .NET 7.0 | 1,140.1 us |  4.04 us |  1.00 |
| Render         | pr   | .NET 8.0 |   711.8 us |  1.49 us |  0.62 |
|                |      |          |            |          |       |
| RenderAdvanced | main | .NET 7.0 | 1,548.4 us |  5.30 us |  1.00 |
| RenderAdvanced | pr   | .NET 8.0 | 1,047.4 us |  4.44 us |  0.68 |

</details>