### PR TITLE
A few more perf improvements

### DIFF
--- a/src/Markdig/Helpers/ThrowHelper.cs
+++ b/src/Markdig/Helpers/ThrowHelper.cs
@@ -80,7 +80,7 @@ internal static class ThrowHelper
         if (depth > limit)
             DepthLimitExceeded();
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [DoesNotReturn]
         static void DepthLimitExceeded() => throw new ArgumentException("Markdown elements in the input are too deeply nested - depth limit exceeded. Input is most likely not sensible or is a very large table.");
     }
 

--- a/src/Markdig/Helpers/UnicodeUtility.cs
+++ b/src/Markdig/Helpers/UnicodeUtility.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Text;
+
+// Based on https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Text/UnicodeUtility.cs
+internal static class UnicodeUtility
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsBmpCodePoint(uint value) => value <= 0xFFFFu;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsValidUnicodeScalar(uint value)
+    {
+        return ((value - 0x110000u) ^ 0xD800u) >= 0xFFEF0800u;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void GetUtf16SurrogatesFromSupplementaryPlaneScalar(uint value, out char highSurrogateCodePoint, out char lowSurrogateCodePoint)
+    {
+        Debug.Assert(IsValidUnicodeScalar(value) && IsBmpCodePoint(value));
+
+        highSurrogateCodePoint = (char)((value + ((0xD800u - 0x40u) << 10)) >> 10);
+        lowSurrogateCodePoint = (char)((value & 0x3FFu) + 0xDC00u);
+    }
+}

--- a/src/Markdig/Polyfills/IndexOfHelpers.cs
+++ b/src/Markdig/Polyfills/IndexOfHelpers.cs
@@ -41,6 +41,13 @@ internal static class IndexOfHelpers
         return -1;
     }
 #endif
+
+#if !NET6_0_OR_GREATER
+    public static bool Contains<T>(this ReadOnlySpan<T> span, T value) where T : IEquatable<T>
+    {
+        return span.IndexOf(value) >= 0;
+    }
+#endif
 }
 
 #endif


### PR DESCRIPTION
- Improves the fenced code block parser a bit
- Avoids a dictionary lookup per object when rendering (using linear scans over small arrays instead)
- Misc

| Method         | Job  | Mean       | Error    | Ratio |
|--------------- |----- |-----------:|---------:|------:|
| Parse          | main | 2,512.1 us | 13.63 us |  1.00 |
| Parse          | pr   | 2,417.2 us | 14.36 us |  0.96 |
|                |      |            |          |       |
| ParseAdvanced  | main | 7,872.1 us | 22.51 us |  1.00 |
| ParseAdvanced  | pr   | 7,906.6 us | 44.54 us |  1.00 |
|                |      |            |          |       |
| Render         | main |   716.3 us |  2.38 us |  1.00 |
| Render         | pr   |   688.6 us |  4.58 us |  0.96 |
|                |      |            |          |       |
| RenderAdvanced | main | 1,073.6 us |  4.24 us |  1.00 |
| RenderAdvanced | pr   |   984.2 us |  6.25 us |  0.92 |