### PR TITLE
Make StringLineGroup returns a count limited Enumerator

### DIFF
--- a/src/Markdig.Tests/TestStringSliceList.cs
+++ b/src/Markdig.Tests/TestStringSliceList.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Text;
 
 using Markdig.Helpers;
@@ -214,5 +215,21 @@ public class TestStringSliceList
         var chars = ToString(iterator);
         TextAssert.AreEqual("ABC\r\nD\r\n", chars.ToString());
         TextAssert.AreEqual("ABC\r\nD", text.ToString());
+    }
+
+    [Test]
+    public void TestStringLineGroup_EnumeratorReturnsRealLines()
+    {
+        string str = "A\r\n";
+        var text = new StringLineGroup(4)
+        {
+            new StringSlice(str, NewLine.CarriageReturnLineFeed) { Start = 0, End = 0 }
+        };
+
+        var enumerator = ((IEnumerable)text).GetEnumerator();
+        Assert.True(enumerator.MoveNext());
+        StringLine currentLine = (StringLine)enumerator.Current;
+        TextAssert.AreEqual("A", currentLine.ToString());
+        Assert.False(enumerator.MoveNext());
     }
 }

--- a/src/Markdig.Tests/TestStringSliceList.cs
+++ b/src/Markdig.Tests/TestStringSliceList.cs
@@ -231,5 +231,12 @@ public class TestStringSliceList
         StringLine currentLine = (StringLine)enumerator.Current;
         TextAssert.AreEqual("A", currentLine.ToString());
         Assert.False(enumerator.MoveNext());
+        
+        var nonBoxedEnumerator = text.GetEnumerator();
+
+        Assert.True(nonBoxedEnumerator.MoveNext());
+        currentLine = (StringLine)nonBoxedEnumerator.Current;
+        TextAssert.AreEqual("A", currentLine.ToString());
+        Assert.False(nonBoxedEnumerator.MoveNext());
     }
 }

--- a/src/Markdig/Helpers/StringLineGroup.cs
+++ b/src/Markdig/Helpers/StringLineGroup.cs
@@ -218,7 +218,7 @@ public struct StringLineGroup : IEnumerable
 
     IEnumerator IEnumerable.GetEnumerator() 
     {
-        (IEnumerator)GetEnumerator();
+        return GetEnumerator();
     }
 
     private void IncreaseCapacity()

--- a/src/Markdig/Helpers/StringLineGroup.cs
+++ b/src/Markdig/Helpers/StringLineGroup.cs
@@ -187,7 +187,7 @@ public struct StringLineGroup : IEnumerable
         }
     }
 
-    private struct Enumerator : IEnumerator
+    public struct Enumerator : IEnumerator
     {
         private readonly StringLineGroup _parent;
         private int _index;
@@ -210,10 +210,15 @@ public struct StringLineGroup : IEnumerable
             _index = -1;
         }
     }
-
-    IEnumerator IEnumerable.GetEnumerator()
+    
+    public Enumerator GetEnumerator()
     {
         return new Enumerator(this);
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() 
+    {
+        (IEnumerator)GetEnumerator();
     }
 
     private void IncreaseCapacity()

--- a/src/Markdig/Helpers/StringLineGroup.cs
+++ b/src/Markdig/Helpers/StringLineGroup.cs
@@ -202,14 +202,7 @@ public struct StringLineGroup : IEnumerable
 
         public bool MoveNext()
         {
-            if (++_index < _parent.Count)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return ++_index < _parent.Count;
         }
 
         public void Reset()

--- a/src/Markdig/Helpers/StringLineGroup.cs
+++ b/src/Markdig/Helpers/StringLineGroup.cs
@@ -187,9 +187,40 @@ public struct StringLineGroup : IEnumerable
         }
     }
 
+    private struct Enumerator : IEnumerator
+    {
+        private readonly StringLineGroup _parent;
+        private int _index;
+
+        public Enumerator(StringLineGroup parent)
+        {
+            _parent = parent;
+            _index = -1;
+        }
+
+        public object Current => _parent.Lines[_index];
+
+        public bool MoveNext()
+        {
+            if (++_index < _parent.Count)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public void Reset()
+        {
+            _index = -1;
+        }
+    }
+
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return Lines.GetEnumerator();
+        return new Enumerator(this);
     }
 
     private void IncreaseCapacity()


### PR DESCRIPTION
Fixes #757, before we return the array enumerator directly, enumerate it will get phantom empty lines.