### PR TITLE
Fix source span calculation for LineBreakInline

### DIFF
--- a/src/Markdig.Tests/TestSourcePosition.cs
+++ b/src/Markdig.Tests/TestSourcePosition.cs
@@ -89,6 +89,38 @@ linebreak    ( 0,10) 10-11
 ", trackTrivia: true);
     }
 
+
+    [Test]
+    public void TestMultipleParagraphsWithEndNewLine()
+    {
+        Check("0123456789\n\n0123456789\n\n", @"
+paragraph    ( 0, 0)  0-10
+literal      ( 0, 0)  0-9
+linebreak    ( 0,10) 10-10
+paragraph    ( 2, 0) 12-22
+literal      ( 2, 0) 12-21
+linebreak    ( 2,10) 22-22
+", trackTrivia: true);
+
+        Check("0123456789\r\r0123456789\r\r", @"
+paragraph    ( 0, 0)  0-10
+literal      ( 0, 0)  0-9
+linebreak    ( 0,10) 10-10
+paragraph    ( 2, 0) 12-22
+literal      ( 2, 0) 12-21
+linebreak    ( 2,10) 22-22
+", trackTrivia: true);
+
+        Check("0123456789\r\n\r\n0123456789\r\n\r\n", @"
+paragraph    ( 0, 0)  0-11
+literal      ( 0, 0)  0-9
+linebreak    ( 0,10) 10-11
+paragraph    ( 2, 0) 14-25
+literal      ( 2, 0) 14-23
+linebreak    ( 2,10) 24-25
+", trackTrivia: true);
+    }
+
     [Test]
     public void TestEmphasis()
     {

--- a/src/Markdig/Parsers/InlineProcessor.cs
+++ b/src/Markdig/Parsers/InlineProcessor.cs
@@ -225,7 +225,7 @@ public class InlineProcessor
         previousLineIndexForSliceOffset = 0;
         lineOffsets.Clear();
         var text = leafBlock.Lines.ToSlice(lineOffsets);
-        var textEnd = text.Length;
+        var textEnd = text.End;
         leafBlock.Lines.Release();
         int previousStart = -1;
 
@@ -320,7 +320,7 @@ public class InlineProcessor
                 var newLine = leafBlock.NewLine;
                 if (newLine != NewLine.None)
                 {
-                    var position = GetSourcePosition(textEnd, out int line, out int column);
+                    var position = GetSourcePosition(textEnd + 1, out int line, out int column);
                     leafBlock.Inline.AppendChild(new LineBreakInline { NewLine = newLine, Line = line, Column = column, Span = { Start = position, End = position + (newLine == NewLine.CarriageReturnLineFeed ? 1 : 0) } });
                 }
             }


### PR DESCRIPTION
Fix the source span calculation of the last `LineBreakInline` in paragraph when multiple blocks exists.

I have added the source span calculation for the last `LineBreakInline` in https://github.com/xoofx/markdig/pull/733, but the logic does not handle multiple blocks correctly. This corrects the logic.