### PR TITLE
Eliminate various string allocations

### DIFF
--- a/src/Markdig.Tests/TestNormalize.cs
+++ b/src/Markdig.Tests/TestNormalize.cs
@@ -52,6 +52,16 @@ public class TestNormalize
     }
 
     [Test]
+    public void SyntaxHeadlineLevel7()
+    {
+        AssertSyntax("####### Headline", new HeadingBlock(null) {
+            HeaderChar = '#',
+            Level = 7,
+            Inline = new ContainerInline().AppendChild(new LiteralInline("Headline")),
+        });
+    }
+
+    [Test]
     public void SyntaxParagraph()
     {
         AssertSyntax("This is a normal paragraph", new ParagraphBlock()

--- a/src/Markdig/Renderers/Normalize/CodeBlockRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/CodeBlockRenderer.cs
@@ -18,9 +18,9 @@ public class CodeBlockRenderer : NormalizeObjectRenderer<CodeBlock>
     {
         if (obj is FencedCodeBlock fencedCodeBlock)
         {
-            var fencedCharCount = Math.Min(fencedCodeBlock.OpeningFencedCharCount, fencedCodeBlock.ClosingFencedCharCount);
-            var opening = new string(fencedCodeBlock.FencedChar, fencedCharCount);
-            renderer.Write(opening);
+            int fencedCharCount = Math.Min(fencedCodeBlock.OpeningFencedCharCount, fencedCodeBlock.ClosingFencedCharCount);
+
+            renderer.Write(fencedCodeBlock.FencedChar, fencedCharCount);
             if (fencedCodeBlock.Info != null)
             {
                 renderer.Write(fencedCodeBlock.Info);
@@ -41,7 +41,7 @@ public class CodeBlockRenderer : NormalizeObjectRenderer<CodeBlock>
             renderer.WriteLine();
 
             renderer.WriteLeafRawLines(obj, true);
-            renderer.Write(opening);
+            renderer.Write(fencedCodeBlock.FencedChar, fencedCharCount);
         }
         else
         {

--- a/src/Markdig/Renderers/Normalize/HeadingRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/HeadingRenderer.cs
@@ -12,22 +12,27 @@ namespace Markdig.Renderers.Normalize;
 /// <seealso cref="NormalizeObjectRenderer{HeadingBlock}" />
 public class HeadingRenderer : NormalizeObjectRenderer<HeadingBlock>
 {
-    private static readonly string[] HeadingTexts = {
+    private static readonly string[] HeadingTexts = [
         "#",
         "##",
         "###",
         "####",
         "#####",
         "######",
-    };
+    ];
 
     protected override void Write(NormalizeRenderer renderer, HeadingBlock obj)
-    {
-        var headingText = obj.Level > 0 && obj.Level <= 6
-            ? HeadingTexts[obj.Level - 1]
-            : new string('#', obj.Level);
+    {        
+        if (obj.Level is > 0 and <= 6)
+        {
+            renderer.Write(HeadingTexts[obj.Level - 1]);
+        }
+        else
+        {
+            renderer.Write('#', obj.Level);            
+        }        
 
-        renderer.Write(headingText).Write(' ');
+        renderer.Write(' ');
         renderer.WriteLeafInline(obj);
 
         renderer.FinishBlock(renderer.Options.EmptyLineAfterHeading);

--- a/src/Markdig/Renderers/Normalize/Inlines/CodeInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/CodeInlineRenderer.cs
@@ -31,8 +31,8 @@ public class CodeInlineRenderer : NormalizeObjectRenderer<CodeInline>
             if (delimiterCount < count)
                 delimiterCount = count;
         }
-        var delimiterRun = new string(obj.Delimiter, delimiterCount + 1);
-        renderer.Write(delimiterRun);
+
+        renderer.Write(obj.Delimiter, delimiterCount + 1);
         if (content.Length != 0)
         {
             if (content[0] == obj.Delimiter)
@@ -49,6 +49,6 @@ public class CodeInlineRenderer : NormalizeObjectRenderer<CodeInline>
         {
             renderer.Write(' ');
         }
-        renderer.Write(delimiterRun);
+        renderer.Write(obj.Delimiter, delimiterCount + 1);
     }
 }

--- a/src/Markdig/Renderers/Normalize/Inlines/EmphasisInlineRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/Inlines/EmphasisInlineRenderer.cs
@@ -14,9 +14,8 @@ public class EmphasisInlineRenderer : NormalizeObjectRenderer<EmphasisInline>
 {
     protected override void Write(NormalizeRenderer renderer, EmphasisInline obj)
     {
-        var emphasisText = new string(obj.DelimiterChar, obj.DelimiterCount);
-        renderer.Write(emphasisText);
+        renderer.Write(obj.DelimiterChar, obj.DelimiterCount);
         renderer.WriteChildren(obj);
-        renderer.Write(emphasisText);
+        renderer.Write(obj.DelimiterChar, obj.DelimiterCount);
     }
 }

--- a/src/Markdig/Renderers/Roundtrip/CodeBlockRenderer.cs
+++ b/src/Markdig/Renderers/Roundtrip/CodeBlockRenderer.cs
@@ -19,8 +19,7 @@ public class CodeBlockRenderer : RoundtripObjectRenderer<CodeBlock>
         if (obj is FencedCodeBlock fencedCodeBlock)
         {
             renderer.Write(obj.TriviaBefore);
-            var opening = new string(fencedCodeBlock.FencedChar, fencedCodeBlock.OpeningFencedCharCount);
-            renderer.Write(opening);
+            renderer.Write(fencedCodeBlock.FencedChar, fencedCodeBlock.OpeningFencedCharCount);
 
             if (!fencedCodeBlock.TriviaAfterFencedChar.IsEmpty)
             {
@@ -56,9 +55,8 @@ public class CodeBlockRenderer : RoundtripObjectRenderer<CodeBlock>
             renderer.WriteLeafRawLines(obj);
 
             renderer.Write(fencedCodeBlock.TriviaBeforeClosingFence);
-            var closing = new string(fencedCodeBlock.FencedChar, fencedCodeBlock.ClosingFencedCharCount);
-            renderer.Write(closing);
-            if (!string.IsNullOrEmpty(closing))
+            renderer.Write(fencedCodeBlock.FencedChar, fencedCodeBlock.ClosingFencedCharCount);
+            if (fencedCodeBlock.ClosingFencedCharCount > 0)
             {
                 // See example 207: "> ```\nfoo\n```"
                 renderer.WriteLine(obj.NewLine);

--- a/src/Markdig/Renderers/Roundtrip/HeadingRenderer.cs
+++ b/src/Markdig/Renderers/Roundtrip/HeadingRenderer.cs
@@ -12,14 +12,14 @@ namespace Markdig.Renderers.Roundtrip;
 /// <seealso cref="RoundtripObjectRenderer{HeadingBlock}" />
 public class HeadingRenderer : RoundtripObjectRenderer<HeadingBlock>
 {
-    private static readonly string[] HeadingTexts = {
+    private static readonly string[] HeadingTexts = [
         "#",
         "##",
         "###",
         "####",
         "#####",
         "######",
-    };
+    ];
 
     protected override void Write(RoundtripRenderer renderer, HeadingBlock obj)
     {
@@ -28,12 +28,11 @@ public class HeadingRenderer : RoundtripObjectRenderer<HeadingBlock>
             renderer.RenderLinesBefore(obj);
 
             var headingChar = obj.Level == 1 ? '=' : '-';
-            var line = new string(headingChar, obj.HeaderCharCount);
 
             renderer.WriteLeafInline(obj);
             renderer.WriteLine(obj.SetextNewline);
             renderer.Write(obj.TriviaBefore);
-            renderer.Write(line);
+            renderer.Write(headingChar, obj.HeaderCharCount);
             renderer.WriteLine(obj.NewLine);
             renderer.Write(obj.TriviaAfter);
 
@@ -43,12 +42,17 @@ public class HeadingRenderer : RoundtripObjectRenderer<HeadingBlock>
         {
             renderer.RenderLinesBefore(obj);
 
-            var headingText = obj.Level > 0 && obj.Level <= 6
-                ? HeadingTexts[obj.Level - 1]
-                : new string('#', obj.Level);
-
             renderer.Write(obj.TriviaBefore);
-            renderer.Write(headingText);
+
+            if (obj.Level is > 0 and <= 6)
+            {
+                renderer.Write(HeadingTexts[obj.Level - 1]);
+            }
+            else
+            {
+                renderer.Write('#', obj.Level);
+            }
+
             renderer.Write(obj.TriviaAfterAtxHeaderChar);
             renderer.WriteLeafInline(obj);
             renderer.Write(obj.TriviaAfter);

--- a/src/Markdig/Renderers/Roundtrip/Inlines/CodeInlineRenderer.cs
+++ b/src/Markdig/Renderers/Roundtrip/Inlines/CodeInlineRenderer.cs
@@ -14,12 +14,11 @@ public class CodeInlineRenderer : RoundtripObjectRenderer<CodeInline>
 {
     protected override void Write(RoundtripRenderer renderer, CodeInline obj)
     {
-        var delimiterRun = new string(obj.Delimiter, obj.DelimiterCount);
-        renderer.Write(delimiterRun);
+        renderer.Write(obj.Delimiter, obj.DelimiterCount);
         if (!obj.ContentSpan.IsEmpty)
         {
             renderer.Write(obj.ContentWithTrivia);
         }
-        renderer.Write(delimiterRun);
+        renderer.Write(obj.Delimiter, obj.DelimiterCount);
     }
 }

--- a/src/Markdig/Renderers/Roundtrip/Inlines/EmphasisInlineRenderer.cs
+++ b/src/Markdig/Renderers/Roundtrip/Inlines/EmphasisInlineRenderer.cs
@@ -14,9 +14,8 @@ public class EmphasisInlineRenderer : RoundtripObjectRenderer<EmphasisInline>
 {
     protected override void Write(RoundtripRenderer renderer, EmphasisInline obj)
     {
-        var emphasisText = new string(obj.DelimiterChar, obj.DelimiterCount);
-        renderer.Write(emphasisText);
+        renderer.Write(obj.DelimiterChar, obj.DelimiterCount);
         renderer.WriteChildren(obj);
-        renderer.Write(emphasisText);
+        renderer.Write(obj.DelimiterChar, obj.DelimiterCount);
     }
 }

--- a/src/Markdig/Renderers/TextRendererBase.cs
+++ b/src/Markdig/Renderers/TextRendererBase.cs
@@ -212,6 +212,25 @@ public abstract class TextRendererBase<T> : TextRendererBase where T : TextRende
     }
 
     /// <summary>
+    /// Writes the specified char repeated a specified number of times.
+    /// </summary>
+    /// <param name="c">The char to write.</param>
+    /// <param name="count">The number of times to write the char.</param>
+    /// <returns>This instance</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal T Write(char c, int count)
+    {
+        WriteIndent();        
+        
+        for (int i = 0; i < count; i++)
+        {
+            Writer.Write(c);
+        }        
+
+        return (T)this;
+    }
+
+    /// <summary>
     /// Writes the specified slice.
     /// </summary>
     /// <param name="slice">The slice.</param>


### PR DESCRIPTION
This PR introduces an overload on TextRendererBase that writes a character a specific number of times, and utilizes it to eliminate various string allocations.
