### PR TITLE
Fixed a typo in MathSpecs.md

### DIFF
--- a/src/Markdig.Tests/Specs/MathSpecs.md
+++ b/src/Markdig.Tests/Specs/MathSpecs.md
@@ -127,7 +127,7 @@ $$ math $$ starting at a line
 
 ## Math Block
 
-The match block can spawn on multiple lines by having a $$ starting on a line.
+The math block can spawn on multiple lines by having a $$ starting on a line.
 It is working as a fenced code block.
 
 ```````````````````````````````` example


### PR DESCRIPTION
Fixing what I assume is a typo in one of the documentation files.