### PR TITLE
Fix math source span

### DIFF
--- a/src/Markdig.Tests/TestSourcePosition.cs
+++ b/src/Markdig.Tests/TestSourcePosition.cs
@@ -699,13 +699,14 @@ literal      ( 0, 2)  2-3
     public void TestMathematicsInline()
     {
         //     01 23456789AB
-        Check("0\n012 $abcd$", @"
-paragraph    ( 0, 0)  0-11
+        Check("0\n012 $abcd$ 321", @"
+paragraph    ( 0, 0)  0-15
 literal      ( 0, 0)  0-0
 linebreak    ( 0, 1)  1-1
 literal      ( 1, 0)  2-5
 math         ( 1, 4)  6-11
 attributes   ( 0, 0)  0--1
+literal      ( 1,10) 12-15
 ", "mathematics");
     }
 

--- a/src/Markdig/Extensions/Mathematics/MathInlineParser.cs
+++ b/src/Markdig/Extensions/Mathematics/MathInlineParser.cs
@@ -152,7 +152,7 @@ public class MathInlineParser : InlineParser
             // Create a new MathInline
             var inline = new MathInline()
             {
-                Span = new SourceSpan(processor.GetSourcePosition(startPosition, out int line, out int column), processor.GetSourcePosition(slice.End)),
+                Span = new SourceSpan(processor.GetSourcePosition(startPosition, out int line, out int column), processor.GetSourcePosition(end)),
                 Line = line,
                 Column = column,
                 Delimiter = match,


### PR DESCRIPTION
Fix math source span calculation.

The span is wrong if a math is followed with more texts:
>  Check("0\n012 \\$abcd\\$ 321", @"
paragraph    ( 0, 0)  0-15
literal      ( 0, 0)  0-0
linebreak    ( 0, 1)  1-1
literal      ( 1, 0)  2-5
**math         ( 1, 4)  6-15** (incorrect)
attributes   ( 0, 0)  0--1
literal      ( 1,10) 12-15
", "mathematics");
