### PR TITLE
Add ConfigureHtmlRenderer to MarkdownPipelineBuilder

### DIFF
--- a/src/Markdig.Tests/RoundtripSpecs/Inlines/TestNullCharacterInline.cs
+++ b/src/Markdig.Tests/RoundtripSpecs/Inlines/TestNullCharacterInline.cs
@@ -22,16 +22,15 @@ namespace Markdig.Tests.RoundtripSpecs.Inlines
         // do not unintentionally use the expected parameter
         private static void RoundTrip(string markdown, string expected)
         {
-            var pipelineBuilder = new MarkdownPipelineBuilder();
-            pipelineBuilder.EnableTrackTrivia();
-            MarkdownPipeline pipeline = pipelineBuilder.Build();
+            var pipeline = new MarkdownPipelineBuilder()
+                .EnableTrackTrivia()
+                .ConfigureRoundtripRenderer()
+                .Build();
+
             MarkdownDocument markdownDocument = Markdown.Parse(markdown, pipeline);
-            var sw = new StringWriter();
-            var rr = new RoundtripRenderer(sw);
+            var result = Markdown.ToHtml(markdownDocument, pipeline);
 
-            rr.Write(markdownDocument);
-
-            Assert.AreEqual(expected, sw.ToString());
+            Assert.AreEqual(expected, result);
         }
     }
 }

--- a/src/Markdig.Tests/TestLinkRewriter.cs
+++ b/src/Markdig.Tests/TestLinkRewriter.cs
@@ -24,17 +24,13 @@ public class TestLinkRewriter
 
     public static void TestSpec(Func<string,string> linkRewriter, string markdown, string expectedLink)
     {
-        var pipeline = new MarkdownPipelineBuilder().Build();
-
-        var writer = new StringWriter();
-        var renderer = new HtmlRenderer(writer);
-        renderer.LinkRewriter = linkRewriter;
-        pipeline.Setup(renderer);
+        var pipeline = new MarkdownPipelineBuilder()
+            .ConfigureHtmlRenderer(r => r.UseLinkRewriter(linkRewriter))
+            .Build();
 
         var document = MarkdownParser.Parse(markdown, pipeline);
-        renderer.Render(document);
-        writer.Flush();
+        var html = Markdown.ToHtml(document, pipeline);
 
-        Assert.That(writer.ToString(), Contains.Substring("=\"" + expectedLink + "\""));
+        Assert.That(html, Contains.Substring("=\"" + expectedLink + "\""));
     }
 }

--- a/src/Markdig.Tests/TestRelativeUrlReplacement.cs
+++ b/src/Markdig.Tests/TestRelativeUrlReplacement.cs
@@ -28,11 +28,7 @@ public class TestRelativeUrlReplacement
     public static void TestSpec(string baseUrl, string markdown, string expectedLink)
     {
         var pipeline = new MarkdownPipelineBuilder()
-            .ConfigureHtmlRenderer((r) =>
-            {
-                if (baseUrl != null)
-                    r.BaseUrl = new Uri(baseUrl);
-            })
+            .ConfigureHtmlRenderer(b => b.UseBaseUrl(baseUrl))
             .Build();
 
         var document = MarkdownParser.Parse(markdown, pipeline);

--- a/src/Markdig.Tests/TestRelativeUrlReplacement.cs
+++ b/src/Markdig.Tests/TestRelativeUrlReplacement.cs
@@ -27,18 +27,17 @@ public class TestRelativeUrlReplacement
 
     public static void TestSpec(string baseUrl, string markdown, string expectedLink)
     {
-        var pipeline = new MarkdownPipelineBuilder().Build();
-
-        var writer = new StringWriter();
-        var renderer = new HtmlRenderer(writer);
-        if (baseUrl != null)
-            renderer.BaseUrl = new Uri(baseUrl);
-        pipeline.Setup(renderer);
+        var pipeline = new MarkdownPipelineBuilder()
+            .ConfigureHtmlRenderer((r) =>
+            {
+                if (baseUrl != null)
+                    r.BaseUrl = new Uri(baseUrl);
+            })
+            .Build();
 
         var document = MarkdownParser.Parse(markdown, pipeline);
-        renderer.Render(document);
-        writer.Flush();
+        var html = Markdown.ToHtml(document, pipeline);
 
-        Assert.That(writer.ToString(), Contains.Substring("=\"" + expectedLink + "\""));
+        Assert.That(html, Contains.Substring("=\"" + expectedLink + "\""));
     }
 }

--- a/src/Markdig.Tests/TestRoundtrip.cs
+++ b/src/Markdig.Tests/TestRoundtrip.cs
@@ -12,18 +12,14 @@ internal static class TestRoundtrip
 
     internal static void RoundTrip(string markdown, string context = null)
     {
-        var pipelineBuilder = new MarkdownPipelineBuilder();
-        pipelineBuilder.EnableTrackTrivia();
-        pipelineBuilder.UseYamlFrontMatter();
-        MarkdownPipeline pipeline = pipelineBuilder.Build();
+        var pipeline = new MarkdownPipelineBuilder()
+            .EnableTrackTrivia()
+            .UseYamlFrontMatter()
+            .ConfigureRoundtripRenderer()
+            .Build();
         MarkdownDocument markdownDocument = Markdown.Parse(markdown, pipeline);
-        var sw = new StringWriter();
-        var nr = new RoundtripRenderer(sw);
-        pipeline.Setup(nr);
 
-        nr.Write(markdownDocument);
-
-        var result = sw.ToString();
+        var result = Markdown.ToHtml(markdownDocument, pipeline);
         TestParser.PrintAssertExpected("", result, markdown, context);
     }
 }

--- a/src/Markdig/Markdown.cs
+++ b/src/Markdig/Markdown.cs
@@ -117,7 +117,7 @@ public static class Markdown
         pipeline ??= DefaultPipeline;
 
         using var rentedRenderer = pipeline.RentHtmlRenderer();
-        HtmlRenderer renderer = rentedRenderer.Instance;
+        var renderer = rentedRenderer.Instance;
 
         renderer.Render(document);
         renderer.Writer.Flush();
@@ -141,7 +141,7 @@ public static class Markdown
         pipeline ??= DefaultPipeline;
 
         using var rentedRenderer = pipeline.RentHtmlRenderer(writer);
-        HtmlRenderer renderer = rentedRenderer.Instance;
+        var renderer = rentedRenderer.Instance;
 
         renderer.Render(document);
         renderer.Writer.Flush();
@@ -166,7 +166,7 @@ public static class Markdown
         var document = MarkdownParser.Parse(markdown, pipeline, context);
 
         using var rentedRenderer = pipeline.RentHtmlRenderer(writer);
-        HtmlRenderer renderer = rentedRenderer.Instance;
+        var renderer = rentedRenderer.Instance;
 
         renderer.Render(document);
         writer.Flush();

--- a/src/Markdig/MarkdownExtensions.cs
+++ b/src/Markdig/MarkdownExtensions.cs
@@ -37,6 +37,7 @@ using Markdig.Parsers;
 using Markdig.Parsers.Inlines;
 using Markdig.Renderers;
 using Markdig.Renderers.Normalize;
+using Markdig.Renderers.Roundtrip;
 
 namespace Markdig;
 
@@ -733,6 +734,16 @@ public static class MarkdownExtensions
         Func<NormalizeRendererBuilder, NormalizeRendererBuilder> configureRenderer)
     {
         pipeline.RendererBuilder = configureRenderer(new NormalizeRendererBuilder());
+        return pipeline;
+    }
+
+    /// <summary>
+    /// Configure the pipeline with a <see cref="RoundtripRenderer"/>.
+    /// </summary>
+    /// <param name="pipeline">The pipeline.</param>
+    public static MarkdownPipelineBuilder ConfigureRoundtripRenderer(this MarkdownPipelineBuilder pipeline)
+    {
+        pipeline.RendererBuilder = new RoundtripRendererBuilder();
         return pipeline;
     }
 

--- a/src/Markdig/MarkdownExtensions.cs
+++ b/src/Markdig/MarkdownExtensions.cs
@@ -36,6 +36,7 @@ using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Parsers.Inlines;
 using Markdig.Renderers;
+using Markdig.Renderers.Normalize;
 
 namespace Markdig;
 
@@ -719,6 +720,19 @@ public static class MarkdownExtensions
         Func<HtmlRendererBuilder, HtmlRendererBuilder> configureRenderer)
     {
         pipeline.RendererBuilder = configureRenderer(new HtmlRendererBuilder());
+        return pipeline;
+    }
+
+    /// <summary>
+    /// Configure the pipeline with a <see cref="NormalizeRenderer"/>.
+    /// </summary>
+    /// <param name="pipeline">The pipeline.</param>
+    /// <param name="configureRenderer">An action which configures the <c>NormalizeRenderer</c>.</param>
+    public static MarkdownPipelineBuilder ConfigureNormalizeRenderer(
+        this MarkdownPipelineBuilder pipeline,
+        Func<NormalizeRendererBuilder, NormalizeRendererBuilder> configureRenderer)
+    {
+        pipeline.RendererBuilder = configureRenderer(new NormalizeRendererBuilder());
         return pipeline;
     }
 

--- a/src/Markdig/MarkdownExtensions.cs
+++ b/src/Markdig/MarkdownExtensions.cs
@@ -709,6 +709,11 @@ public static class MarkdownExtensions
         return pipeline;
     }
 
+    /// <summary>
+    /// Configure the pipeline with a <see cref="HtmlRenderer"/>.
+    /// </summary>
+    /// <param name="pipeline">The pipeline.</param>
+    /// <param name="configureRenderer">An action which configures the <c>HtmlRenderer</c>.</param>
     public static MarkdownPipelineBuilder ConfigureHtmlRenderer(
         this MarkdownPipelineBuilder pipeline,
         Func<HtmlRendererBuilder, HtmlRendererBuilder> configureRenderer)
@@ -717,6 +722,11 @@ public static class MarkdownExtensions
         return pipeline;
     }
 
+    /// <summary>
+    /// Configure the pipeline to use a <see cref="IMarkdownRendererBuilder"/> to construct the renderer.
+    /// </summary>
+    /// <param name="pipeline">The pipeline.</param>
+    /// <param name="rendererBuilder">The builder for the renderer.</param>
     public static MarkdownPipelineBuilder UseRendererBuilder(
         this MarkdownPipelineBuilder pipeline,
         IMarkdownRendererBuilder rendererBuilder)

--- a/src/Markdig/MarkdownExtensions.cs
+++ b/src/Markdig/MarkdownExtensions.cs
@@ -719,10 +719,7 @@ public static class MarkdownExtensions
     public static MarkdownPipelineBuilder ConfigureHtmlRenderer(
         this MarkdownPipelineBuilder pipeline,
         Func<HtmlRendererBuilder, HtmlRendererBuilder> configureRenderer)
-    {
-        pipeline.RendererBuilder = configureRenderer(new HtmlRendererBuilder());
-        return pipeline;
-    }
+        => pipeline.UseRendererBuilder(configureRenderer(new HtmlRendererBuilder()));
 
     /// <summary>
     /// Configure the pipeline with a <see cref="NormalizeRenderer"/>.
@@ -732,20 +729,14 @@ public static class MarkdownExtensions
     public static MarkdownPipelineBuilder ConfigureNormalizeRenderer(
         this MarkdownPipelineBuilder pipeline,
         Func<NormalizeRendererBuilder, NormalizeRendererBuilder> configureRenderer)
-    {
-        pipeline.RendererBuilder = configureRenderer(new NormalizeRendererBuilder());
-        return pipeline;
-    }
+        => pipeline.UseRendererBuilder(configureRenderer(new NormalizeRendererBuilder()));
 
     /// <summary>
     /// Configure the pipeline with a <see cref="RoundtripRenderer"/>.
     /// </summary>
     /// <param name="pipeline">The pipeline.</param>
     public static MarkdownPipelineBuilder ConfigureRoundtripRenderer(this MarkdownPipelineBuilder pipeline)
-    {
-        pipeline.RendererBuilder = new RoundtripRendererBuilder();
-        return pipeline;
-    }
+        => pipeline.UseRendererBuilder(new RoundtripRendererBuilder());
 
     /// <summary>
     /// Configure the pipeline to use a <see cref="IMarkdownRendererBuilder"/> to construct the renderer.

--- a/src/Markdig/MarkdownExtensions.cs
+++ b/src/Markdig/MarkdownExtensions.cs
@@ -108,7 +108,6 @@ public static class MarkdownExtensions
         pipeline.Extensions.ReplaceOrAdd<AlertExtension>(new AlertExtension() { RenderKind = renderKind });
         return pipeline;
     }
-    
     /// <summary>
     /// Uses this extension to enable autolinks from text `http://`, `https://`, `ftp://`, `mailto:`, `www.xxx.yyy`
     /// </summary>
@@ -706,6 +705,12 @@ public static class MarkdownExtensions
         {
             parser.InfoParser = FencedCodeBlockParser.RoundtripInfoParser;
         }
+        return pipeline;
+    }
+
+    public static MarkdownPipelineBuilder ConfigureHtmlRenderer(this MarkdownPipelineBuilder pipeline, Action<HtmlRenderer> configureHtmlRenderer)
+    {
+        pipeline.ConfigureHtmlRenderer = configureHtmlRenderer;
         return pipeline;
     }
 }

--- a/src/Markdig/MarkdownExtensions.cs
+++ b/src/Markdig/MarkdownExtensions.cs
@@ -108,7 +108,7 @@ public static class MarkdownExtensions
         pipeline.Extensions.ReplaceOrAdd<AlertExtension>(new AlertExtension() { RenderKind = renderKind });
         return pipeline;
     }
-    
+
     /// <summary>
     /// Uses this extension to enable autolinks from text `http://`, `https://`, `ftp://`, `mailto:`, `www.xxx.yyy`
     /// </summary>
@@ -711,7 +711,7 @@ public static class MarkdownExtensions
 
     public static MarkdownPipelineBuilder ConfigureHtmlRenderer(this MarkdownPipelineBuilder pipeline, Action<HtmlRenderer> configureHtmlRenderer)
     {
-        pipeline.ConfigureHtmlRenderer = configureHtmlRenderer;
+        pipeline.ConfigureHtmlRendererAction = configureHtmlRenderer;
         return pipeline;
     }
 }

--- a/src/Markdig/MarkdownExtensions.cs
+++ b/src/Markdig/MarkdownExtensions.cs
@@ -709,9 +709,19 @@ public static class MarkdownExtensions
         return pipeline;
     }
 
-    public static MarkdownPipelineBuilder ConfigureHtmlRenderer(this MarkdownPipelineBuilder pipeline, Action<HtmlRenderer> configureHtmlRenderer)
+    public static MarkdownPipelineBuilder ConfigureHtmlRenderer(
+        this MarkdownPipelineBuilder pipeline,
+        Func<HtmlRendererBuilder, HtmlRendererBuilder> configureRenderer)
     {
-        pipeline.ConfigureHtmlRendererAction = configureHtmlRenderer;
+        pipeline.RendererBuilder = configureRenderer(new HtmlRendererBuilder());
+        return pipeline;
+    }
+
+    public static MarkdownPipelineBuilder UseRendererBuilder(
+        this MarkdownPipelineBuilder pipeline,
+        IMarkdownRendererBuilder rendererBuilder)
+    {
+        pipeline.RendererBuilder = rendererBuilder;
         return pipeline;
     }
 }

--- a/src/Markdig/MarkdownExtensions.cs
+++ b/src/Markdig/MarkdownExtensions.cs
@@ -108,6 +108,7 @@ public static class MarkdownExtensions
         pipeline.Extensions.ReplaceOrAdd<AlertExtension>(new AlertExtension() { RenderKind = renderKind });
         return pipeline;
     }
+    
     /// <summary>
     /// Uses this extension to enable autolinks from text `http://`, `https://`, `ftp://`, `mailto:`, `www.xxx.yyy`
     /// </summary>

--- a/src/Markdig/MarkdownPipelineBuilder.cs
+++ b/src/Markdig/MarkdownPipelineBuilder.cs
@@ -90,7 +90,7 @@ public class MarkdownPipelineBuilder
 
     internal ProcessDocumentDelegate? GetDocumentProcessed => DocumentProcessed;
 
-    internal Action<HtmlRenderer>? ConfigureHtmlRenderer;
+    internal Action<HtmlRenderer>? ConfigureHtmlRendererAction;
 
     /// <summary>
     /// Builds a pipeline from this instance. Once the pipeline is build, it cannot be modified.
@@ -124,7 +124,7 @@ public class MarkdownPipelineBuilder
             new InlineParserList(InlineParsers),
             DebugLog,
             GetDocumentProcessed,
-            ConfigureHtmlRenderer)
+            ConfigureHtmlRendererAction)
         {
             PreciseSourceLocation = PreciseSourceLocation,
             TrackTrivia = TrackTrivia,

--- a/src/Markdig/MarkdownPipelineBuilder.cs
+++ b/src/Markdig/MarkdownPipelineBuilder.cs
@@ -7,6 +7,7 @@ using System.IO;
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Parsers.Inlines;
+using Markdig.Renderers;
 
 namespace Markdig;
 
@@ -89,6 +90,8 @@ public class MarkdownPipelineBuilder
 
     internal ProcessDocumentDelegate? GetDocumentProcessed => DocumentProcessed;
 
+    internal Action<HtmlRenderer>? ConfigureHtmlRenderer;
+
     /// <summary>
     /// Builds a pipeline from this instance. Once the pipeline is build, it cannot be modified.
     /// </summary>
@@ -120,7 +123,8 @@ public class MarkdownPipelineBuilder
             new BlockParserList(BlockParsers),
             new InlineParserList(InlineParsers),
             DebugLog,
-            GetDocumentProcessed)
+            GetDocumentProcessed,
+            ConfigureHtmlRenderer)
         {
             PreciseSourceLocation = PreciseSourceLocation,
             TrackTrivia = TrackTrivia,

--- a/src/Markdig/MarkdownPipelineBuilder.cs
+++ b/src/Markdig/MarkdownPipelineBuilder.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
-// This file is licensed under the BSD-Clause 2 license. 
+// This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
 using System.IO;
@@ -90,7 +90,7 @@ public class MarkdownPipelineBuilder
 
     internal ProcessDocumentDelegate? GetDocumentProcessed => DocumentProcessed;
 
-    internal Action<HtmlRenderer>? ConfigureHtmlRendererAction;
+    internal IMarkdownRendererBuilder? RendererBuilder;
 
     /// <summary>
     /// Builds a pipeline from this instance. Once the pipeline is build, it cannot be modified.
@@ -124,7 +124,7 @@ public class MarkdownPipelineBuilder
             new InlineParserList(InlineParsers),
             DebugLog,
             GetDocumentProcessed,
-            ConfigureHtmlRendererAction)
+            RendererBuilder)
         {
             PreciseSourceLocation = PreciseSourceLocation,
             TrackTrivia = TrackTrivia,

--- a/src/Markdig/Renderers/HtmlRenderer.cs
+++ b/src/Markdig/Renderers/HtmlRenderer.cs
@@ -48,7 +48,7 @@ public class HtmlRenderer : TextRendererBase<HtmlRenderer>
         ObjectRenderers.Add(new EmphasisInlineRenderer());
         ObjectRenderers.Add(new LineBreakInlineRenderer());
         ObjectRenderers.Add(new HtmlInlineRenderer());
-        ObjectRenderers.Add(new HtmlEntityInlineRenderer());            
+        ObjectRenderers.Add(new HtmlEntityInlineRenderer());
         ObjectRenderers.Add(new LinkInlineRenderer());
         ObjectRenderers.Add(new LiteralInlineRenderer());
 
@@ -206,11 +206,11 @@ public class HtmlRenderer : TextRendererBase<HtmlRenderer>
                 content = new Uri(BaseUrl, contentUri).AbsoluteUri;
             else
             {
-                var builder = new UriBuilder(BaseUrl);
-                if (!builder.Path.EndsWith("/"))
-                    builder.Path += "/";
-                builder.Path += contentUri.ToString();
-                content = builder.Uri.ToString();
+                var baseUrl = BaseUrl.ToString();
+                content = baseUrl;
+                if (!baseUrl.EndsWith("/"))
+                    content += "/";
+                content += contentUri.ToString();
             }
         }
 

--- a/src/Markdig/Renderers/HtmlRenderer.cs
+++ b/src/Markdig/Renderers/HtmlRenderer.cs
@@ -202,7 +202,16 @@ public class HtmlRenderer : TextRendererBase<HtmlRenderer>
             // this is the proper cross-platform way to check whether a uri is absolute or not:
             && Uri.TryCreate(content, UriKind.RelativeOrAbsolute, out var contentUri) && !contentUri.IsAbsoluteUri)
         {
-            content = new Uri(BaseUrl, contentUri).AbsoluteUri;
+            if (BaseUrl.IsAbsoluteUri)
+                content = new Uri(BaseUrl, contentUri).AbsoluteUri;
+            else
+            {
+                var builder = new UriBuilder(BaseUrl);
+                if (!builder.Path.EndsWith("/"))
+                    builder.Path += "/";
+                builder.Path += contentUri.ToString();
+                content = builder.Uri.ToString();
+            }
         }
 
         if (LinkRewriter != null)

--- a/src/Markdig/Renderers/HtmlRendererBuilder.cs
+++ b/src/Markdig/Renderers/HtmlRendererBuilder.cs
@@ -6,30 +6,72 @@ using System.IO;
 
 namespace Markdig.Renderers;
 
+/// <summary>
+/// This class is used with <see cref="MarkdownExtensions.ConfigureHtmlRenderer"/>
+/// to set up a pipeline with a html renderer.
+/// </summary>
 public class HtmlRendererBuilder : IMarkdownRendererBuilder
 {
-    public Uri? BaseUrl { get; private set; }
+    private Uri? baseUrl;
+    private bool? enableHtmlEscape;
+    private bool? enableHtmlForBlock;
+    private bool? enableHtmlForInline;
+    private bool? useNonAsciiNoEscape;
 
     public HtmlRenderer Build(TextWriter writer)
     {
         HtmlRenderer htmlRenderer = new HtmlRenderer(writer);
 
-        if (BaseUrl != null) htmlRenderer.BaseUrl = BaseUrl;
+        if (baseUrl != null) htmlRenderer.BaseUrl = baseUrl;
+        if (enableHtmlEscape != null) htmlRenderer.EnableHtmlEscape = enableHtmlEscape.Value;
+        if (enableHtmlForBlock != null) htmlRenderer.EnableHtmlForBlock = enableHtmlForBlock.Value;
+        if (enableHtmlForInline != null) htmlRenderer.EnableHtmlForInline = enableHtmlForInline.Value;
+        if (useNonAsciiNoEscape != null) htmlRenderer.UseNonAsciiNoEscape = useNonAsciiNoEscape.Value;
 
         return htmlRenderer;
     }
 
     TextRendererBase IMarkdownRendererBuilder.Build(TextWriter writer) => Build(writer);
 
+    /// <inheritdoc cref="HtmlRenderer.BaseUrl"/>
     public HtmlRendererBuilder UseBaseUrl(string baseUrl)
     {
-        BaseUrl = baseUrl != null ? new Uri(baseUrl) : null;
+        this.baseUrl = baseUrl != null ? new Uri(baseUrl) : null;
         return this;
     }
 
+    /// <inheritdoc cref="HtmlRenderer.BaseUrl"/>
     public HtmlRendererBuilder UseBaseUrl(Uri baseUrl)
     {
-        BaseUrl = baseUrl;
+        this.baseUrl = baseUrl;
+        return this;
+    }
+
+    /// <inheritdoc cref="HtmlRenderer.EnableHtmlEscape"/>
+    public HtmlRendererBuilder EnableHtmlEscape(bool enable)
+    {
+        enableHtmlEscape = enable;
+        return this;
+    }
+
+    /// <inheritdoc cref="HtmlRenderer.EnableHtmlForBlock"/>
+    public HtmlRendererBuilder EnableHtmlForBlock(bool enable)
+    {
+        enableHtmlForBlock = enable;
+        return this;
+    }
+
+    /// <inheritdoc cref="HtmlRenderer.EnableHtmlForInline"/>
+    public HtmlRendererBuilder EnableHtmlForInline(bool enable)
+    {
+        enableHtmlForInline = enable;
+        return this;
+    }
+
+    /// <inheritdoc cref="HtmlRenderer.UseNonAsciiNoEscape"/>
+    public HtmlRendererBuilder UseNonAsciiNoEscape(bool enable)
+    {
+        useNonAsciiNoEscape = enable;
         return this;
     }
 }

--- a/src/Markdig/Renderers/HtmlRendererBuilder.cs
+++ b/src/Markdig/Renderers/HtmlRendererBuilder.cs
@@ -17,6 +17,7 @@ public class HtmlRendererBuilder : IMarkdownRendererBuilder
     private bool? enableHtmlForBlock;
     private bool? enableHtmlForInline;
     private bool? useNonAsciiNoEscape;
+    public Func<string, string>? linkRewriter;
 
     public HtmlRenderer Build(TextWriter writer)
     {
@@ -27,6 +28,7 @@ public class HtmlRendererBuilder : IMarkdownRendererBuilder
         if (enableHtmlForBlock != null) htmlRenderer.EnableHtmlForBlock = enableHtmlForBlock.Value;
         if (enableHtmlForInline != null) htmlRenderer.EnableHtmlForInline = enableHtmlForInline.Value;
         if (useNonAsciiNoEscape != null) htmlRenderer.UseNonAsciiNoEscape = useNonAsciiNoEscape.Value;
+        if (linkRewriter != null) htmlRenderer.LinkRewriter = linkRewriter;
 
         return htmlRenderer;
     }
@@ -72,6 +74,13 @@ public class HtmlRendererBuilder : IMarkdownRendererBuilder
     public HtmlRendererBuilder UseNonAsciiNoEscape(bool enable)
     {
         useNonAsciiNoEscape = enable;
+        return this;
+    }
+
+    /// <inheritdoc cref="HtmlRenderer.LinkRewriter"/>
+    public HtmlRendererBuilder UseLinkRewriter(Func<string,string> linkRewriter)
+    {
+        this.linkRewriter = linkRewriter;
         return this;
     }
 }

--- a/src/Markdig/Renderers/HtmlRendererBuilder.cs
+++ b/src/Markdig/Renderers/HtmlRendererBuilder.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+using System.IO;
+
+namespace Markdig.Renderers;
+
+public class HtmlRendererBuilder : IMarkdownRendererBuilder
+{
+    public Uri? BaseUrl { get; private set; }
+
+    public HtmlRenderer Build(TextWriter writer)
+    {
+        HtmlRenderer htmlRenderer = new HtmlRenderer(writer);
+
+        if (BaseUrl != null) htmlRenderer.BaseUrl = BaseUrl;
+
+        return htmlRenderer;
+    }
+
+    TextRendererBase IMarkdownRendererBuilder.Build(TextWriter writer) => Build(writer);
+
+    public HtmlRendererBuilder UseBaseUrl(string baseUrl)
+    {
+        BaseUrl = baseUrl != null ? new Uri(baseUrl) : null;
+        return this;
+    }
+
+    public HtmlRendererBuilder UseBaseUrl(Uri baseUrl)
+    {
+        BaseUrl = baseUrl;
+        return this;
+    }
+}

--- a/src/Markdig/Renderers/IMarkdownRendererBuilder.cs
+++ b/src/Markdig/Renderers/IMarkdownRendererBuilder.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+using System.IO;
+
+namespace Markdig.Renderers;
+
+public interface IMarkdownRendererBuilder {
+    TextRendererBase Build(TextWriter writer);
+}

--- a/src/Markdig/Renderers/IMarkdownRendererBuilder.cs
+++ b/src/Markdig/Renderers/IMarkdownRendererBuilder.cs
@@ -6,6 +6,17 @@ using System.IO;
 
 namespace Markdig.Renderers;
 
+/// <summary>
+/// Defines a common interface for all rendererer builders.
+/// </summary>
 public interface IMarkdownRendererBuilder {
+    /// <summary>
+    /// Creates a new instance of a renderer for use in a pipeline.
+    /// </summary>
+    /// <remarks>
+    /// The renderer needs to be a subclass of <see cref="TextRendererBase"/>
+    /// because it is intended to be used by <see cref="MarkdownPipeline.HtmlRendererCache"/> which depends on
+    /// <see cref="TextRendererBase.ResetInternal"/> for re-use.
+    /// </remarks>
     TextRendererBase Build(TextWriter writer);
 }

--- a/src/Markdig/Renderers/Normalize/NormalizeRendererBuilder.cs
+++ b/src/Markdig/Renderers/Normalize/NormalizeRendererBuilder.cs
@@ -1,0 +1,62 @@
+using System.IO;
+
+namespace Markdig.Renderers.Normalize;
+
+
+/// <summary>
+/// This class is used with <see cref="MarkdownExtensions.ConfigureNormalizeRenderer"/>
+/// to set up a pipeline with a normalizing renderer.
+/// </summary>
+public class NormalizeRendererBuilder : IMarkdownRendererBuilder
+{
+    private readonly Lazy<NormalizeOptions> options = new(() => new NormalizeOptions());
+
+    public NormalizeRenderer Build(TextWriter writer)
+    {
+        return new NormalizeRenderer(writer, options.IsValueCreated ? options.Value : null);
+    }
+
+    TextRendererBase IMarkdownRendererBuilder.Build(TextWriter writer) => Build(writer);
+
+    /// <inheritdoc cref="NormalizeOptions.SpaceAfterQuoteBlock" />
+    public NormalizeRendererBuilder UseSpaceAfterQuoteBlock(bool enable)
+    {
+        options.Value.SpaceAfterQuoteBlock = enable;
+        return this;
+    }
+
+    /// <inheritdoc cref="NormalizeOptions.EmptyLineAfterCodeBlock" />
+    public NormalizeRendererBuilder UseEmptyLineAfterCodeBlock(bool enable)
+    {
+        options.Value.EmptyLineAfterCodeBlock = enable;
+        return this;
+    }
+
+    /// <inheritdoc cref="NormalizeOptions.EmptyLineAfterHeading" />
+    public NormalizeRendererBuilder UseEmptyLineAfterHeading(bool enable)
+    {
+        options.Value.EmptyLineAfterHeading = enable;
+        return this;
+    }
+
+    /// <inheritdoc cref="NormalizeOptions.EmptyLineAfterThematicBreak" />
+    public NormalizeRendererBuilder UseEmptyLineAfterThematicBreak(bool enable)
+    {
+        options.Value.EmptyLineAfterThematicBreak = enable;
+        return this;
+    }
+
+    /// <inheritdoc cref="NormalizeOptions.ListItemCharacter" />
+    public NormalizeRendererBuilder UseListItemCharacter(char? character)
+    {
+        options.Value.ListItemCharacter = character;
+        return this;
+    }
+
+    /// <inheritdoc cref="NormalizeOptions.ExpandAutoLinks" />
+    public NormalizeRendererBuilder ExpandAutoLinks(bool enable)
+    {
+        options.Value.ExpandAutoLinks = enable;
+        return this;
+    }
+}

--- a/src/Markdig/Renderers/Normalize/NormalizeRendererBuilder.cs
+++ b/src/Markdig/Renderers/Normalize/NormalizeRendererBuilder.cs
@@ -1,3 +1,7 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
 using System.IO;
 
 namespace Markdig.Renderers.Normalize;

--- a/src/Markdig/Renderers/Roundtrip/RoundtripRendererBuilder.cs
+++ b/src/Markdig/Renderers/Roundtrip/RoundtripRendererBuilder.cs
@@ -1,0 +1,19 @@
+using System.IO;
+
+namespace Markdig.Renderers.Roundtrip;
+
+/// <summary>
+/// This class is used with <see cref="MarkdownExtensions.ConfigureRoundtripRenderer"/>
+/// to set up a pipeline with a markdown renderer.
+/// </summary>
+/// <remarks>
+/// This builder has no options since <see cref="RoundtripRenderer"/> has none.
+/// It is solely in use internally in <see cref="MarkdownExtensions.ConfigureRoundtripRenderer"/>
+/// because <see cref="MarkdownPipelineBuilder"/> can only use a renderer builder, not a renderer.
+/// </remarks>
+class RoundtripRendererBuilder : IMarkdownRendererBuilder
+{
+    public RoundtripRenderer Build(TextWriter writer) => new(writer);
+
+    TextRendererBase IMarkdownRendererBuilder.Build(TextWriter writer) => Build(writer);
+}

--- a/src/Markdig/Renderers/Roundtrip/RoundtripRendererBuilder.cs
+++ b/src/Markdig/Renderers/Roundtrip/RoundtripRendererBuilder.cs
@@ -1,3 +1,7 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
 using System.IO;
 
 namespace Markdig.Renderers.Roundtrip;

--- a/src/Markdig/Renderers/TextRendererBase.cs
+++ b/src/Markdig/Renderers/TextRendererBase.cs
@@ -61,6 +61,12 @@ public abstract class TextRendererBase : RendererBase
         Write(markdownObject);
         return Writer;
     }
+
+    internal virtual void ResetInternal()
+    {
+
+    }
+
 }
 
 /// <summary>
@@ -134,7 +140,7 @@ public abstract class TextRendererBase<T> : TextRendererBase where T : TextRende
         ResetInternal();
     }
 
-    internal void ResetInternal()
+    internal override void ResetInternal()
     {
         _childrenDepth = 0;
         previousWasLine = true;


### PR DESCRIPTION
I needed to set up image url rewriting in a project of mine and found it a bit tedious not having a way to set it up in the pipeline. So I added the ability to configure the `HtmlRenderer` from the pipeline builder. As an added bonus, this works with the renderer cache as well.

I did not add any tests but updated the BaseUrl test to configure the html renderer using the pipeline builder.
I did not update changelog.md since it already has been neglected for some time.
I have not spent any time figuring out whether any of the documentation should be updated, please advise.
I could not find any existing PR or issue on this exact issue so I took the liberty to raise this draft PR.

UPDATE:
I added a bare bones builder for HtmlRenderer letting me set the one field I need as a POC. It is basically a factory for `TextRendererBase` which I also refactored the cache mechanism to use so that too should work for any text renderer. This goes for the `ToHtml` method since it uses the caching mechanism to get hold of its renderer.