### PR TITLE
Fix extra line feeds in link title

### DIFF
--- a/src/Markdig.Tests/TestLinkHelper.cs
+++ b/src/Markdig.Tests/TestLinkHelper.cs
@@ -82,6 +82,14 @@ public class TestLinkHelper
     }
 
     [Test]
+    public void TestTitleMultiline()
+    {
+        var text = new StringSlice("'this\ris\r\na\ntitle'");
+        Assert.True(LinkHelper.TryParseTitle(ref text, out string title, out _));
+        Assert.AreEqual("this\ris\r\na\ntitle", title);
+    }
+
+    [Test]
     public void TestUrlAndTitle()
     {
         //                           0         1         2         3

--- a/src/Markdig/Helpers/LinkHelper.cs
+++ b/src/Markdig/Helpers/LinkHelper.cs
@@ -567,6 +567,7 @@ public static class LinkHelper
                     if (c == '\r' && text.PeekChar() == '\n')
                     {
                         buffer.Append('\n');
+                        text.SkipChar();
                     }
                     continue;
                 }
@@ -663,6 +664,7 @@ public static class LinkHelper
                     if (c == '\r' && text.PeekChar() == '\n')
                     {
                         buffer.Append('\n');
+                        text.SkipChar();
                     }
                     continue;
                 }


### PR DESCRIPTION
Extra line feeds appear in the parsed link titles containing Windows-style line breaks, because \n that is peeked after \r is not skipped.