### PR TITLE
Set delimiter char and count in CustomContainerInline instances.

### DIFF
--- a/src/Markdig/Extensions/CustomContainers/CustomContainerExtension.cs
+++ b/src/Markdig/Extensions/CustomContainers/CustomContainerExtension.cs
@@ -30,7 +30,11 @@ public class CustomContainerExtension : IMarkdownExtension
             {
                 if (delimiterCount == 2 && emphasisChar == ':')
                 {
-                    return new CustomContainerInline();
+                    return new CustomContainerInline
+                    {
+                        DelimiterChar = ':',
+                        DelimiterCount = 2
+                    };
                 }
                 return null;
             });


### PR DESCRIPTION
`DelimiterChar` and `DelimiterCount` were not assigned in newly created `CustomContainerInline` instances, which is inconvenient if `CustomContainerInline` is treated like a base `EmphasisInline`.