### PR TITLE
Fix an incorrect offset in GridTableParser.

### DIFF
--- a/src/Markdig/Extensions/Tables/GridTableParser.cs
+++ b/src/Markdig/Extensions/Tables/GridTableParser.cs
@@ -256,7 +256,7 @@ public class GridTableParser : BlockParser
                 {
                     sliceForCell.End = line.Start + columnEnd - 1;
                 }
-                else if (line.PeekCharExtra(line.End) == '|')
+                else if (line.PeekCharExtra(line.End - line.Start) == '|')
                 {
                     sliceForCell.End = line.End - 1;
                 }


### PR DESCRIPTION
Instead of the intended index to the table line content, an offset to the global source is used. The resulting offset is beyond the end of the table line, and if there happens to be a bar '|' there, the last character of the line is cut off.

For example:
```
// 01234567 8 9012345 6 7890123
  "+--+--+\r\n|11|12\r\n>     |"
```
The start of the second line of the table (9) + the line end (14) is 23, and there is a bar at 23. So this string results in a table containing "11", "1" (not "12").