### PR TITLE
Fix an error in the AbbreviationParser.

### DIFF
--- a/src/Markdig.Tests/TestSourcePosition.cs
+++ b/src/Markdig.Tests/TestSourcePosition.cs
@@ -533,13 +533,17 @@ literal      ( 1, 6)  8-9
     [Test]
     public void TestAbbreviations()
     {
-        Check("*[HTML]: Hypertext Markup Language\r\n\r\nLater in a text we are using HTML and it becomes an abbr tag HTML", @"
+        Check("*[HTML]: Hypertext Markup Language\r\n\r\nLater in a text we are using HTML and it becomes an abbr tag HTML\r\n\r\nHTML abbreviation at the beginning of a line", @"
 paragraph    ( 2, 0) 38-102
 container    ( 2, 0) 38-102
 literal      ( 2, 0) 38-66
 abbreviation ( 2,29) 67-70
 literal      ( 2,33) 71-98
 abbreviation ( 2,61) 99-102
+paragraph    ( 4, 0) 107-150
+container    ( 4, 0) 107-150
+abbreviation ( 4, 0) 107-110
+literal      ( 4, 4) 111-150
 ", "abbreviations");
     }
 

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
@@ -171,7 +171,7 @@ public class AbbreviationParser : BlockParser
                     // Process the remaining literal
                     literal = new LiteralInline()
                     {
-                        Span = new SourceSpan(abbrInline.Span.End + 1, literal.Span.End),
+                        Span = new SourceSpan(abbrInline.Span.End + 1, container.Span.End),
                         Line = line,
                         Column = column + match.Length,
                     };

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
@@ -89,6 +89,7 @@ public class AbbreviationParser : BlockParser
         {
             var literal = (LiteralInline)processor.Inline!;
             var originalLiteral = literal;
+            var originalSpanEnd = literal.Span.End;
 
             ContainerInline? container = null;
 
@@ -171,7 +172,7 @@ public class AbbreviationParser : BlockParser
                     // Process the remaining literal
                     literal = new LiteralInline()
                     {
-                        Span = new SourceSpan(abbrInline.Span.End + 1, container.Span.End),
+                        Span = new SourceSpan(abbrInline.Span.End + 1, originalSpanEnd),
                         Line = line,
                         Column = column + match.Length,
                     };


### PR DESCRIPTION
The modified end of the previous literal is assigned to the literal next to abbrevion. The test of the abbreviations in TestSourcePosition.cs passes only because there is an abbreviation at the end of the string, and thus no literal remains after it. But add some literals after the abbreviation, say, a period '.', and instead of expected literal with the span 103-103 there will be one with the end less then the start (103-98).