### PR TITLE
Check that the alert candidate is not already in an alert block or nested within other elements.

### DIFF
--- a/src/Markdig.Tests/MiscTests.cs
+++ b/src/Markdig.Tests/MiscTests.cs
@@ -317,4 +317,31 @@ $$
         Assert.That(paragraph.Inline.Span.Start == paragraph.Inline.FirstChild.Span.Start);
         Assert.That(paragraph.Inline.Span.End == paragraph.Inline.LastChild.Span.End);
     }
+
+    [Test]
+    public void TestAlertWithinAlertOrNestedBlock()
+    {
+        var input = @"
+>[!NOTE]
+[!NOTE]
+The second one is not a note.
+
+>>[!NOTE]
+Also not a note.
+";
+
+        var expected = @"<div class=""markdown-alert markdown-alert-note"">
+<p class=""markdown-alert-title""><svg viewBox=""0 0 16 16"" version=""1.1"" width=""16"" height=""16"" aria-hidden=""true""><path d=""M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z""></path></svg>Note</p>
+<p>[!NOTE]
+The second one is not a note.</p>
+</div>
+<blockquote>
+<blockquote>
+<p>[!NOTE]
+Also not a note.</p>
+</blockquote>
+</blockquote>
+";
+        TestParser.TestSpec(input, expected, new MarkdownPipelineBuilder().UseAlertBlocks().Build());
+    }
 }

--- a/src/Markdig/Extensions/Alerts/AlertInlineParser.cs
+++ b/src/Markdig/Extensions/Alerts/AlertInlineParser.cs
@@ -29,7 +29,8 @@ public class AlertInlineParser : InlineParser
         // We expect the alert to be the first child of a quote block. Example:
         // > [!NOTE]
         // > This is a note
-        if (processor.Block is not ParagraphBlock paragraphBlock || paragraphBlock.Parent is not QuoteBlock quoteBlock || paragraphBlock.Inline?.FirstChild != null)
+        if (processor.Block is not ParagraphBlock paragraphBlock || paragraphBlock.Parent is not QuoteBlock quoteBlock || paragraphBlock.Inline?.FirstChild != null
+            || quoteBlock is AlertBlock || quoteBlock.Parent is not MarkdownDocument)
         {
             return false;
         }


### PR DESCRIPTION
Fixes #841.

The second condition is related to the following GitHub Markdown [update note](https://github.com/orgs/community/discussions/16925):
> - Prevent alerts from being nested within other elements.