### PR TITLE
Fixes exception in DefinitionListParser.GetCurrentDefinitionList()

### DIFF
--- a/src/Markdig.Tests/MiscTests.cs
+++ b/src/Markdig.Tests/MiscTests.cs
@@ -317,4 +317,26 @@ $$
         Assert.That(paragraph.Inline.Span.Start == paragraph.Inline.FirstChild.Span.Start);
         Assert.That(paragraph.Inline.Span.End == paragraph.Inline.LastChild.Span.End);
     }
+
+    [Test]
+    public void TestDefinitionListInListItemWithBlankLine()
+    {
+        var input = @"
+- 
+
+  term
+  :   definition
+";
+
+        var expected = @"<ul>
+<li>
+<dl>
+<dt>term</dt>
+<dd>definition</dd>
+</dl>
+</li>
+</ul>
+";
+        TestParser.TestSpec(input, expected, new MarkdownPipelineBuilder().UseDefinitionLists().Build());
+    }
 }

--- a/src/Markdig/Extensions/DefinitionLists/DefinitionListParser.cs
+++ b/src/Markdig/Extensions/DefinitionLists/DefinitionListParser.cs
@@ -105,13 +105,20 @@ public class DefinitionListParser : BlockParser
     {
         var index = previousParent.IndexOf(paragraphBlock) - 1;
         if (index < 0) return null;
-        var lastBlock = previousParent[index];
-        if (lastBlock is BlankLineBlock)
+        switch (previousParent[index])
         {
-            lastBlock = previousParent[index - 1];
-            previousParent.RemoveAt(index);
+            case DefinitionList definitionList:
+                return definitionList;
+
+            case BlankLineBlock:
+                if (index > 0 && previousParent[index - 1] is DefinitionList definitionList2)
+                {
+                    previousParent.RemoveAt(index);
+                    return definitionList2;
+                }
+                break;
         }
-        return lastBlock as DefinitionList;
+        return null;
     }
 
     public override BlockState TryContinue(BlockProcessor processor, Block block)


### PR DESCRIPTION
Fixes #839.