### PR TITLE
Prevent GridTableParser from looking beyond the end of a line.

### DIFF
--- a/src/Markdig.Tests/MiscTests.cs
+++ b/src/Markdig.Tests/MiscTests.cs
@@ -317,4 +317,24 @@ $$
         Assert.That(paragraph.Inline.Span.Start == paragraph.Inline.FirstChild.Span.Start);
         Assert.That(paragraph.Inline.Span.End == paragraph.Inline.LastChild.Span.End);
     }
+
+    [Test]
+    public void TestGridTableShortLine()
+    {
+        var input = @"
++--+
+|  |
++-";
+
+        var expected = @"<table>
+<col style=""width:100%"" />
+<tbody>
+<tr>
+<td></td>
+</tr>
+</tbody>
+</table>
+";
+        TestParser.TestSpec(input, expected, new MarkdownPipelineBuilder().UseGridTables().Build());
+    }
 }

--- a/src/Markdig/Extensions/Tables/GridTableParser.cs
+++ b/src/Markdig/Extensions/Tables/GridTableParser.cs
@@ -135,6 +135,7 @@ public class GridTableParser : BlockParser
     private static void SetRowSpanState(List<GridTableState.ColumnSlice> columns, StringSlice line, out bool isHeaderRow, out bool hasRowSpan)
     {
         var lineStart = line.Start;
+        var lineEnd = line.End;
         isHeaderRow = line.PeekChar() == '=' || line.PeekChar(2) == '=';
         hasRowSpan = false;
         foreach (var columnSlice in columns)
@@ -142,7 +143,7 @@ public class GridTableParser : BlockParser
             if (columnSlice.CurrentCell != null)
             {
                 line.Start = lineStart + columnSlice.Start + 1;
-                line.End = lineStart + columnSlice.End - 1;
+                line.End = Math.Min(lineStart + columnSlice.End - 1, lineEnd);
                 line.Trim();
                 if (line.IsEmptyOrWhitespace() || !IsRowSeparator(line))
                 {


### PR DESCRIPTION
Fixes #840.