### PR TITLE
Replace encoding polyfill with NET5+ one.

### DIFF
--- a/src/Markdig/Polyfills/EncodingExtensions.cs
+++ b/src/Markdig/Polyfills/EncodingExtensions.cs
@@ -2,7 +2,7 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
-#if !NETSTANDARD2_1_OR_GREATER
+#if !NETCOREAPP2_1_OR_GREATER && !NETSTANDARD2_1_OR_GREATER
 
 using System.Runtime.InteropServices;
 


### PR DESCRIPTION
netstandard2.1 is a special TFM that .NET5+ doesn't mark themselves compitable, even if they mostly are.