### PR TITLE
Infer pipe table column widths from separator row

### DIFF
--- a/src/Markdig.Tests/TestPipeTable.cs
+++ b/src/Markdig.Tests/TestPipeTable.cs
@@ -12,10 +12,47 @@ public sealed class TestPipeTable
     [TestCase("| S | \r\n|---|\r\n| G |\r\n\r\n| D | D |\r\n| ---| ---| \r\n| V | V |", 2)]
     public void TestTableBug(string markdown, int tableCount = 1)
     {
-        MarkdownDocument document = Markdown.Parse(markdown, new MarkdownPipelineBuilder().UseAdvancedExtensions().Build());
+        MarkdownDocument document =
+            Markdown.Parse(markdown, new MarkdownPipelineBuilder().UseAdvancedExtensions().Build());
 
         Table[] tables = document.Descendants().OfType<Table>().ToArray();
 
         Assert.AreEqual(tableCount, tables.Length);
+    }
+
+    [TestCase("A | B\r\n---|---", new[] {50.0f, 50.0f})]
+    [TestCase("A | B\r\n-|---", new[] {25.0f, 75.0f})]
+    [TestCase("A | B\r\n-|---\r\nA | B\r\n---|---", new[] {25.0f, 75.0f})]
+    [TestCase("A | B\r\n---|---|---", new[] {33.33f, 33.33f, 33.33f})]
+    [TestCase("A | B\r\n---|---|---|", new[] {33.33f, 33.33f, 33.33f})]
+    public void TestColumnWidthByHeaderLines(string markdown, float[] expectedWidth)
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UsePipeTables(new PipeTableOptions() {InferColumnWidthsFromSeparator = true})
+            .Build();
+        var document = Markdown.Parse(markdown, pipeline);
+        var table = document.Descendants().OfType<Table>().FirstOrDefault();
+        Assert.IsNotNull(table);
+        var actualWidths = table.ColumnDefinitions.Select(x => x.Width).ToList();
+        Assert.AreEqual(actualWidths.Count, expectedWidth.Length);
+        for (int i = 0; i < expectedWidth.Length; i++)
+        {
+            Assert.AreEqual(actualWidths[i], expectedWidth[i], 0.01);
+        }
+    }
+
+    [Test]
+    public void TestColumnWidthIsNotSetWithoutConfigurationFlag()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UsePipeTables(new PipeTableOptions() {InferColumnWidthsFromSeparator = false})
+            .Build();
+        var document = Markdown.Parse("| A | B | C |\r\n|---|---|---|", pipeline);
+        var table = document.Descendants().OfType<Table>().FirstOrDefault();
+        Assert.IsNotNull(table);
+        foreach (var column in table.ColumnDefinitions)
+        {
+            Assert.AreEqual(0, column.Width);
+        }
     }
 }

--- a/src/Markdig/Extensions/Tables/GridTableParser.cs
+++ b/src/Markdig/Extensions/Tables/GridTableParser.cs
@@ -43,7 +43,7 @@ public class GridTableParser : BlockParser
             }
 
             // Parse a column alignment
-            if (!TableHelper.ParseColumnHeader(ref line, '-', out TableColumnAlign? columnAlign))
+            if (!TableHelper.ParseColumnHeader(ref line, '-', out TableColumnAlign? columnAlign, out _))
             {
                 return BlockState.None;
             }

--- a/src/Markdig/Extensions/Tables/PipeTableOptions.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableOptions.cs
@@ -33,4 +33,11 @@ public class PipeTableOptions
     /// in all other rows (default behavior).
     /// </summary>
     public bool UseHeaderForColumnCount { get; set; }
+
+
+    /// <summary>
+    /// Gets or sets a value indicating whether column widths should be inferred based on the number of dashes
+    /// in the header separator row. Each column's width will be proportional to the dash count in its respective column.
+    /// </summary>
+    public bool InferColumnWidthsFromSeparator { get; set; }
 }

--- a/src/Markdig/Extensions/Tables/TableHelper.cs
+++ b/src/Markdig/Extensions/Tables/TableHelper.cs
@@ -17,12 +17,13 @@ public static class TableHelper
     /// <param name="slice">The text slice.</param>
     /// <param name="delimiterChar">The delimiter character (either `-` or `=`).</param>
     /// <param name="align">The alignment of the column.</param>
+    /// <param name="delimiterCount">The number of delimiters.</param>
     /// <returns>
     ///   <c>true</c> if parsing was successful
     /// </returns>
-    public static bool ParseColumnHeader(ref StringSlice slice, char delimiterChar, out TableColumnAlign? align)
+    public static bool ParseColumnHeader(ref StringSlice slice, char delimiterChar, out TableColumnAlign? align, out int delimiterCount)
     {
-        return ParseColumnHeaderDetect(ref slice, ref delimiterChar, out align);
+        return ParseColumnHeaderDetect(ref slice, ref delimiterChar, out align, out delimiterCount);
     }
 
     /// <summary>
@@ -37,7 +38,7 @@ public static class TableHelper
     public static bool ParseColumnHeaderAuto(ref StringSlice slice, out char delimiterChar, out TableColumnAlign? align)
     {
         delimiterChar = '\0';
-        return ParseColumnHeaderDetect(ref slice, ref delimiterChar, out align);
+        return ParseColumnHeaderDetect(ref slice, ref delimiterChar, out align, out _);
     }
 
     /// <summary>
@@ -49,10 +50,10 @@ public static class TableHelper
     /// <returns>
     ///   <c>true</c> if parsing was successful
     /// </returns>
-    public static bool ParseColumnHeaderDetect(ref StringSlice slice, ref char delimiterChar, out TableColumnAlign? align)
+    public static bool ParseColumnHeaderDetect(ref StringSlice slice, ref char delimiterChar, out TableColumnAlign? align, out int delimiterCount)
     {
         align = null;
-
+        delimiterCount = 0;
         slice.TrimStart();
         var c = slice.CurrentChar;
         bool hasLeft = false;
@@ -80,7 +81,8 @@ public static class TableHelper
         }
 
         // We expect at least one `-` delimiter char
-        if (slice.CountAndSkipChar(delimiterChar) == 0)
+        delimiterCount = slice.CountAndSkipChar(delimiterChar);
+        if (delimiterCount == 0)
         {
             return false;
         }


### PR DESCRIPTION
Hi

First off, thank you for your great library — I use it to convert Markdown to Open XML in my [DocxTemplater](https://github.com/Amberg/DocxTemplater), and it’s been working beautifully.

In my use case, I needed a way to control column widths in pipe tables. Unfortunately, the grid table syntax wasn't an option because it requires monospaced fonts.

This PR introduces a small but useful enhancement:

###  What’s included

- Adds support for inferring column widths in pipe tables based on the number of dashes in the header separator row.
- Activates this behavior via a new option: `PipeTableOptions.InferColumnWidthsFromSeparator`.
- Includes unit tests to ensure the feature works with different table layouts and dash distributions.

This allows authors to write tables like:

```markdown
A | B | C
--|----|--
```

…to get column widths of  25%, 50%, 25%, depending on the relative dash count.

Let me know if you'd like changes or further refinements — happy to adjust!

Thanks again for your work!