### PR TITLE
Fix `MathInline` is called "math block"

### DIFF
--- a/src/Markdig.Tests/Specs/MathSpecs.md
+++ b/src/Markdig.Tests/Specs/MathSpecs.md
@@ -4,79 +4,79 @@ Adds support for mathematics spans:
 
 ## Math Inline
  
-Allows to define a mathematic block embraced by `$...$`
+Allows to define a mathematic inline block embraced by `$...$`
 
 ```````````````````````````````` example
-This is a $math block$
+This is a $math inline$
 .
-<p>This is a <span class="math">\(math block\)</span></p>
+<p>This is a <span class="math">\(math inline\)</span></p>
 ````````````````````````````````
 
 Or by `$$...$$` embracing it by:
 
 ```````````````````````````````` example
-This is a $$math block$$
+This is a $$math inline$$
 .
-<p>This is a <span class="math">\(math block\)</span></p>
+<p>This is a <span class="math">\(math inline\)</span></p>
 ````````````````````````````````
 
 Newlines inside an inline math are not allowed:
 
 ```````````````````````````````` example
 This is not a $$math 
-block$$ and? this is a $$math block$$
+inline$$ and? this is a $$math inline$$
 .
 <p>This is not a $$math
-block$$ and? this is a <span class="math">\(math block\)</span></p>
+inline$$ and? this is a <span class="math">\(math inline\)</span></p>
 ````````````````````````````````
 
 ```````````````````````````````` example
 This is not a $math 
-block$ and? this is a $math block$
+inline$ and? this is a $math inline$
 .
 <p>This is not a $math
-block$ and? this is a <span class="math">\(math block\)</span></p>
+inline$ and? this is a <span class="math">\(math inline\)</span></p>
 ````````````````````````````````
 An opening `$` can be followed by a space if the closing is also preceded by a space `$`:
 
 ```````````````````````````````` example
-This is a $ math block $
+This is a $ math inline $
 .
-<p>This is a <span class="math">\(math block\)</span></p>
+<p>This is a <span class="math">\(math inline\)</span></p>
 ````````````````````````````````
 
 ```````````````````````````````` example
-This is a $    math block     $ after
+This is a $    math inline     $ after
 .
-<p>This is a <span class="math">\(math block\)</span> after</p>
+<p>This is a <span class="math">\(math inline\)</span> after</p>
 ````````````````````````````````
 
 ```````````````````````````````` example
-This is a $$    math block     $$ after
+This is a $$    math inline     $$ after
 .
-<p>This is a <span class="math">\(math block\)</span> after</p>
+<p>This is a <span class="math">\(math inline\)</span> after</p>
 ````````````````````````````````
 
 ```````````````````````````````` example
-This is a not $ math block$ because there is not a whitespace before the closing
+This is a not $ math inline$ because there is not a whitespace before the closing
 .
-<p>This is a not $ math block$ because there is not a whitespace before the closing</p>
+<p>This is a not $ math inline$ because there is not a whitespace before the closing</p>
 ````````````````````````````````
 
 For the opening `$` it requires a space or a punctuation before (but cannot be used within a word):
 
 ```````````````````````````````` example
-This is not a m$ath block$
+This is not a m$ath inline$
 .
-<p>This is not a m$ath block$</p>
+<p>This is not a m$ath inline$</p>
 ````````````````````````````````
 
 For the closing `$` it requires a space after or a punctuation (but cannot be preceded by a space and cannot be used within a word):
 
 ```````````````````````````````` example
-This is not a $math bloc$k
+This is not a $math inlin$e
 .
-<p>This is not a $math bloc$k</p>
+<p>This is not a $math inlin$e</p>
 ````````````````````````````````
 
 For the closing `$` it requires a space after or a punctuation (but cannot be preceded by a space and cannot be used within a word):
@@ -90,34 +90,34 @@ This is should not match a 16$ or a $15
 A `$` can be escaped between a math inline block by using the escape `\\` 
 
 ```````````````````````````````` example
-This is a $math \$ block$
+This is a $math \$ inline$
 .
-<p>This is a <span class="math">\(math \$ block\)</span></p>
+<p>This is a <span class="math">\(math \$ inline\)</span></p>
 ````````````````````````````````
 
 At most, two `$` will be matched for the opening and closing:
 
 ```````````````````````````````` example
-This is a $$$math block$$$
+This is a $$$math inline$$$
 .
-<p>This is a <span class="math">\($math block$\)</span></p>
+<p>This is a <span class="math">\($math inline$\)</span></p>
 ````````````````````````````````
 
 Regular text can come both before and after the math inline
 
 ```````````````````````````````` example
-This is a $math block$ with text on both sides.
+This is a $math inline$ with text on both sides.
 .
-<p>This is a <span class="math">\(math block\)</span> with text on both sides.</p>
+<p>This is a <span class="math">\(math inline\)</span> with text on both sides.</p>
 ````````````````````````````````
-A mathematic block takes precedence over standard emphasis `*` `_`:
+A mathematic inline block takes precedence over standard emphasis `*` `_`:
 
 ```````````````````````````````` example
-This is *a $math* block$
+This is *a $math* inline$
 .
-<p>This is *a <span class="math">\(math* block\)</span></p>
+<p>This is *a <span class="math">\(math* inline\)</span></p>
 ````````````````````````````````
-An opening $$ at the beginning of a line should not be interpreted as a Math block:
+An opening $$ at the beginning of a line should not be interpreted as a Math inline:
 
 ```````````````````````````````` example
 $$ math $$ starting at a line


### PR DESCRIPTION
It is really confusing that `MathInline` is called "math block".