### PR TITLE
Improve Alert parsing perf

### DIFF
--- a/src/Markdig/Extensions/Alerts/AlertBlock.cs
+++ b/src/Markdig/Extensions/Alerts/AlertBlock.cs
@@ -22,7 +22,7 @@ public class AlertBlock : QuoteBlock
     }
 
     /// <summary>
-    /// Gets or sets the kind of the alert block (e.g `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, `CAUTION`)
+    /// Gets or sets the kind of the alert block (e.g `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, `CAUTION`).
     /// </summary>
     public StringSlice Kind { get; set; }
 

--- a/src/Markdig/MarkdownPipeline.cs
+++ b/src/Markdig/MarkdownPipeline.cs
@@ -127,7 +127,7 @@ public sealed class MarkdownPipeline
         }
     }
 
-    internal readonly struct RentedHtmlRenderer : IDisposable
+    internal readonly ref struct RentedHtmlRenderer : IDisposable
     {
         private readonly HtmlRendererCache _cache;
         public readonly HtmlRenderer Instance;

--- a/src/Markdig/Syntax/MarkdownObject.cs
+++ b/src/Markdig/Syntax/MarkdownObject.cs
@@ -153,7 +153,7 @@ public abstract class MarkdownObject : IMarkdownObject
         return Unsafe.As<T>(storage.Trivia);
     }
 
-    private class DataEntriesAndTrivia
+    private sealed class DataEntriesAndTrivia
     {
         private struct DataEntry(object key, object value)
         {

--- a/src/Markdig/Syntax/QuoteBlock.cs
+++ b/src/Markdig/Syntax/QuoteBlock.cs
@@ -25,7 +25,7 @@ public class QuoteBlock : ContainerBlock
 
     /// <summary>
     /// Gets or sets the trivia per line of this QuoteBlock.
-    /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled, otherwise null.
+    /// Trivia: only parsed when <see cref="MarkdownPipeline.TrackTrivia"/> is enabled.
     /// </summary>
     public List<QuoteBlockLine> QuoteLines => Trivia;
 


### PR DESCRIPTION
- Do the fast-path check for `!` first since that's likely to fail to lower the overhead on text with lots of regular links.
- Avoid the string allocations for `$"markdown-alert-{alertType.ToString().ToLowerInvariant()}"`
  - alertType substring + lowercase + concat result