### PR TITLE
Remove module-level [SkipLocalsInit] to prevent native crashes on AOT platforms (iOS/Android)

### DIFF
--- a/src/Markdig/SkipLocalsInit.cs
+++ b/src/Markdig/SkipLocalsInit.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Alexandre Mutel. All rights reserved.
-// This file is licensed under the BSD-Clause 2 license.
-// See the license.txt file in the project root for more information.
-
-#if NET5_0_OR_GREATER
-[module: System.Runtime.CompilerServices.SkipLocalsInit]
-#endif


### PR DESCRIPTION
This PR removes the following directive:

```csharp
#if NET5_0_OR_GREATER
[module: System.Runtime.CompilerServices.SkipLocalsInit]
#endif
```

to resolve native crashes on mobile platforms (specifically catched on iOS and Android when using .NET 9 in MAUI app).

🧯 The Problem

In high-throughput UI scenarios (e.g. extremely fast list scrolling in MAUI), calls to:

```csharp
Markdown.Parse(string, MarkdownPipeline)
```

began randomly triggering crashes. After isolating the issue, removing [SkipLocalsInit] fully resolved the problem.
Removing it ensures cross-platform safety and improves compatibility mobile/AOT targets.

Issue describing the case: https://github.com/xoofx/markdig/issues/873

"This attribute is unsafe, because it may reveal uninitialized memory to the application in certain instances (for example, reading from uninitialized stack-allocated memory). If applied to a method directly, the attribute applies to that method and all its nested functions, including lambdas and local functions. If applied to a type or module, it applies to all methods nested inside. This attribute is intentionally not permitted on assemblies. To apply the attribute to multiple type declarations, use it at the module level instead."
— [docs.microsoft.com](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.skiplocalsinitattribute)

🚀 Impact
Fixes crashes in mobile apps using Markdig.  Improves confidence for developers using Markdig in MAUI, Unity, Blazor Hybrid, and other non-Windows environments.  

Please let me know if you'd prefer the attribute be conditionally compiled or applied to only select methods, would happy to adjust.