### PR TITLE
Fix #872 by reserve null title string.

### DIFF
--- a/src/Markdig.Tests/TestLinkHelper.cs
+++ b/src/Markdig.Tests/TestLinkHelper.cs
@@ -112,26 +112,26 @@ public class TestLinkHelper
     }
 
     [Test]
-    public void TestUrlAndTitleEmpty()
+    public void TestUrlEmptyAndTitleNull()
     {
         //                           01234
         var text = new StringSlice(@"(<>)A");
         Assert.True(LinkHelper.TryParseInlineLink(ref text, out string link, out string title, out SourceSpan linkSpan, out SourceSpan titleSpan));
         Assert.AreEqual(string.Empty, link);
-        Assert.AreEqual(string.Empty, title);
+        Assert.AreEqual(null, title);
         Assert.AreEqual(new SourceSpan(1, 2), linkSpan);
         Assert.AreEqual(SourceSpan.Empty, titleSpan);
         Assert.AreEqual('A', text.CurrentChar);
     }
 
     [Test]
-    public void TestUrlAndTitleEmpty2()
+    public void TestUrlEmptyAndTitleNull2()
     {
         //                           012345
         var text = new StringSlice(@"( <> )A");
         Assert.True(LinkHelper.TryParseInlineLink(ref text, out string link, out string title, out SourceSpan linkSpan, out SourceSpan titleSpan));
         Assert.AreEqual(string.Empty, link);
-        Assert.AreEqual(string.Empty, title);
+        Assert.AreEqual(null, title);
         Assert.AreEqual(new SourceSpan(2, 3), linkSpan);
         Assert.AreEqual(SourceSpan.Empty, titleSpan);
         Assert.AreEqual('A', text.CurrentChar);
@@ -158,7 +158,7 @@ public class TestLinkHelper
         var text = new StringSlice(@"()A");
         Assert.True(LinkHelper.TryParseInlineLink(ref text, out string link, out string title, out SourceSpan linkSpan, out SourceSpan titleSpan));
         Assert.AreEqual(string.Empty, link);
-        Assert.AreEqual(string.Empty, title);
+        Assert.AreEqual(null, title);
         Assert.AreEqual(SourceSpan.Empty, linkSpan);
         Assert.AreEqual(SourceSpan.Empty, titleSpan);
         Assert.AreEqual('A', text.CurrentChar);

--- a/src/Markdig/Helpers/HtmlHelper.cs
+++ b/src/Markdig/Helpers/HtmlHelper.cs
@@ -470,6 +470,24 @@ public static class HtmlHelper
     /// </summary>
     /// <param name="text">The string data that will be changed by unescaping any punctuation or symbol characters.</param>
     /// <param name="removeBackSlash">if set to <c>true</c> [remove back slash].</param>
+    /// <returns>Unescaped text, or null if <paramref name="text"/> is null.<returns>
+    public static string? UnescapeNullable(string? text, bool removeBackSlash = true)
+    {
+        if (text == null)
+        {
+            return null;
+        }
+        else
+        {
+            return Unescape(text, removeBackSlash);
+        }
+    }
+
+    /// <summary>
+    /// Destructively unescape a string: remove backslashes before punctuation or symbol characters.
+    /// </summary>
+    /// <param name="text">The string data that will be changed by unescaping any punctuation or symbol characters.</param>
+    /// <param name="removeBackSlash">if set to <c>true</c> [remove back slash].</param>
     /// <returns></returns>
     public static string Unescape(string? text, bool removeBackSlash = true)
     {

--- a/src/Markdig/Helpers/HtmlHelper.cs
+++ b/src/Markdig/Helpers/HtmlHelper.cs
@@ -470,24 +470,6 @@ public static class HtmlHelper
     /// </summary>
     /// <param name="text">The string data that will be changed by unescaping any punctuation or symbol characters.</param>
     /// <param name="removeBackSlash">if set to <c>true</c> [remove back slash].</param>
-    /// <returns>Unescaped text, or null if <paramref name="text"/> is null.<returns>
-    public static string? UnescapeNullable(string? text, bool removeBackSlash = true)
-    {
-        if (text == null)
-        {
-            return null;
-        }
-        else
-        {
-            return Unescape(text, removeBackSlash);
-        }
-    }
-
-    /// <summary>
-    /// Destructively unescape a string: remove backslashes before punctuation or symbol characters.
-    /// </summary>
-    /// <param name="text">The string data that will be changed by unescaping any punctuation or symbol characters.</param>
-    /// <param name="removeBackSlash">if set to <c>true</c> [remove back slash].</param>
     /// <returns></returns>
     public static string Unescape(string? text, bool removeBackSlash = true)
     {

--- a/src/Markdig/Helpers/LinkHelper.cs
+++ b/src/Markdig/Helpers/LinkHelper.cs
@@ -411,7 +411,7 @@ public static class LinkHelper
         {
             // Skip ')'
             text.SkipChar();
-            // not to normalize nulls
+            // not to normalize nulls into empty strings, since LinkInline.Title property is nullable.
         }
 
         return isValid;

--- a/src/Markdig/Helpers/LinkHelper.cs
+++ b/src/Markdig/Helpers/LinkHelper.cs
@@ -411,7 +411,7 @@ public static class LinkHelper
         {
             // Skip ')'
             text.SkipChar();
-            title ??= string.Empty;
+            // not to normalize nulls
         }
 
         return isValid;

--- a/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
@@ -260,7 +260,7 @@ public class LinkInlineParser : InlineParser
                     link = new LinkInline()
                     {
                         Url = HtmlHelper.Unescape(url, removeBackSlash: false),
-                        Title = HtmlHelper.UnescapeNullable(title, removeBackSlash: false),
+                        Title = title is null ? null : HtmlHelper.Unescape(title, removeBackSlash: false),
                         IsImage = openParent.IsImage,
                         LabelSpan = openParent.LabelSpan,
                         UrlSpan = inlineState.GetSourcePositionFromLocalSpan(linkSpan),

--- a/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
@@ -260,7 +260,7 @@ public class LinkInlineParser : InlineParser
                     link = new LinkInline()
                     {
                         Url = HtmlHelper.Unescape(url, removeBackSlash: false),
-                        Title = HtmlHelper.Unescape(title, removeBackSlash: false),
+                        Title = HtmlHelper.UnescapeNullable(title, removeBackSlash: false),
                         IsImage = openParent.IsImage,
                         LabelSpan = openParent.LabelSpan,
                         UrlSpan = inlineState.GetSourcePositionFromLocalSpan(linkSpan),


### PR DESCRIPTION
#872 reported an inconsistency between nullable annotation and possible value. In case of no title exists in a link syntax, consumers except `Title` property returns a null string. But current behavior is `Title` returning an empty string, This PR fixes the inconsistency by make `Title` property null if link title is not exist.