### PR TITLE
Fixes #878: RoundtripRenderer: render indent and 0 blocks for ordered lists

### DIFF
--- a/src/Markdig.Tests/RoundtripSpecs/TestUnorderedList.cs
+++ b/src/Markdig.Tests/RoundtripSpecs/TestUnorderedList.cs
@@ -25,6 +25,7 @@ public class TestUnorderedList
     [TestCase("-\ti1")]
     [TestCase("-\ti1\n-\ti2")]
     [TestCase("-\ti1\n-  i2\n-\ti3")]
+    [TestCase("- 1.\n- 2.")]
     public void Test(string value)
     {
         RoundTrip(value);

--- a/src/Markdig/Renderers/Roundtrip/ListRenderer.cs
+++ b/src/Markdig/Renderers/Roundtrip/ListRenderer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
-// This file is licensed under the BSD-Clause 2 license. 
+// This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
 using Markdig.Helpers;
@@ -28,7 +28,15 @@ public class ListRenderer : RoundtripObjectRenderer<ListBlock>
                 var bullet = listItem.SourceBullet.ToString();
                 var delimiter = listBlock.OrderedDelimiter;
                 renderer.PushIndent(new string[] { $"{bws}{bullet}{delimiter}" });
-                renderer.WriteChildren(listItem);
+                if (listItem.Count == 0)
+                {
+                    renderer.Write(""); // trigger writing of indent
+                }
+                else
+                {
+                    renderer.WriteChildren(listItem);
+                }
+                renderer.PopIndent();
                 renderer.RenderLinesAfter(listItem);
             }
         }


### PR DESCRIPTION
fixes #878 by supporting indent and 0 blocks