### PR TITLE
Add support for a table without an extra new line before it

### DIFF
--- a/src/Markdig.Tests/TestPipeTable.cs
+++ b/src/Markdig.Tests/TestPipeTable.cs
@@ -10,6 +10,8 @@ public sealed class TestPipeTable
     [TestCase("| S | T |\r\n|---|---|\t\r\n| G | H |")]
     [TestCase("| S | T |\r\n|---|---|\f\r\n| G | H |")]
     [TestCase("| S | \r\n|---|\r\n| G |\r\n\r\n| D | D |\r\n| ---| ---| \r\n| V | V |", 2)]
+    [TestCase("a\r| S | T |\r|---|---|")]
+    [TestCase("a\n| S | T |\r|---|---|")]
     public void TestTableBug(string markdown, int tableCount = 1)
     {
         MarkdownDocument document =

--- a/src/Markdig/Extensions/Tables/PipeTableParser.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableParser.cs
@@ -48,6 +48,7 @@ public class PipeTableParser : InlineParser, IPostInlineProcessor
         }
 
         var c = slice.CurrentChar;
+        var isNewLineFollowedByPipe = (c == '\n' || c == '\r') && slice.PeekChar() == '|';
 
         // If we have not a delimiter on the first line of a paragraph, don't bother to continue
         // tracking other delimiters on following lines
@@ -60,18 +61,17 @@ public class PipeTableParser : InlineParser, IPostInlineProcessor
 
         if (tableState is null)
         {
-
             // A table could be preceded by an empty line or a line containing an inline
             // that has not been added to the stack, so we consider this as a valid
             // start for a table. Typically, with this, we can have an attributes {...}
             // starting on the first line of a pipe table, even if the first line
             // doesn't have a pipe
-            if (processor.Inline != null && (localLineIndex > 0 || c == '\n' || c == '\r'))
+            if (processor.Inline != null && (localLineIndex > 0 || c == '\n' || c == '\r') && !isNewLineFollowedByPipe)
             {
                 return false;
             }
 
-            if (processor.Inline is null)
+            if (processor.Inline is null || isNewLineFollowedByPipe)
             {
                 isFirstLineEmpty = true;
             }


### PR DESCRIPTION
Fixes the following issue where a table will not be rendered if there isn't an extra line before the table. 
https://github.com/xoofx/markdig/issues/818

For example this will not render correctly

```
Here is the table:
| Key   | Value    |
| ----  | -------- |
| Color | Blue     |
| Size  | Medium   |
```
But this will because there's an extra new line before the table starts

```
Here is the table:

| Key   | Value    |
| ----  | -------- |
| Color | Blue     |
| Size  | Medium   |
```

Not handled in this change - whitespace between the new line and the pipe