### PR TITLE
Fixes issue #845

### DIFF
--- a/src/Markdig/Parsers/ListBlockParser.cs
+++ b/src/Markdig/Parsers/ListBlockParser.cs
@@ -145,6 +145,7 @@ public class ListBlockParser : BlockParser
             if (list.CountBlankLinesReset == 1 && listItem.ColumnWidth < 0)
             {
                 state.Close(listItem);
+                list.CountBlankLinesReset = 0;
 
                 // Leave the list open
                 list.IsOpen = true;


### PR DESCRIPTION
This PR fixes the bug reported in issue #845.
With this fix, in the following case:

```csharp
var result = Markdown.ToHtml("-\n\n-\n\n  foo");
```

This result will be produced:
```
<ul>
<li></li>
<li></li>
</ul>
<p>foo</p>
```