### PR TITLE
Fix issue where an inline code block that spans multiple lines doesn't parse correctly

### DIFF
--- a/src/Markdig.Tests/TestPipeTable.cs
+++ b/src/Markdig.Tests/TestPipeTable.cs
@@ -1,5 +1,7 @@
+using Markdig;
 using Markdig.Extensions.Tables;
 using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
 
 namespace Markdig.Tests;
 
@@ -100,5 +102,73 @@ public sealed class TestPipeTable
         Assert.DoesNotThrow(() => html = Markdown.ToHtml(markdown, pipeline));
         Assert.That(html, Does.Contain("<table"));
         Assert.That(html, Does.Contain("<td>`C</td>"));
+    }
+
+    [Test]
+    public void CodeInlineWithPipeDelimitersRemainsCodeInline()
+    {
+        const string markdown = "`|| hidden text ||`";
+
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseAdvancedExtensions()
+            .Build();
+
+        var document = Markdown.Parse(markdown, pipeline);
+
+        var codeInline = document.Descendants().OfType<CodeInline>().SingleOrDefault();
+        Assert.IsNotNull(codeInline);
+        Assert.That(codeInline!.Content, Is.EqualTo("|| hidden text ||"));
+    }
+
+    [Test]
+    public void SingleLineCodeInlineWithPipeDelimitersRendersAsCode()
+    {
+        const string markdown = "`|| hidden text ||`";
+
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseAdvancedExtensions()
+            .Build();
+
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        Assert.That(html, Is.EqualTo("<p><code>|| hidden text ||</code></p>\n"));
+    }
+
+    [Test]
+    public void MultiLineCodeInlineWithPipeDelimitersRendersAsCode()
+    {
+        const string markdown = """
+`
+|| hidden text ||
+`
+""";
+
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseAdvancedExtensions()
+            .Build();
+
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        Assert.That(html, Is.EqualTo("<p><code>|| hidden text ||</code></p>\n"));
+    }
+
+    [Test]
+    public void TableCellWithCodeInlineRendersCorrectly()
+    {
+        const string markdown = """
+| Count | A | B | C | D | E |
+|-------|---|---|---|---|---|
+|     0 | B | C | D | E | F |
+|     1 | B | `Code block` | D | E | F |
+|     2 | B | C | D | E | F |
+""";
+
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseAdvancedExtensions()
+            .Build();
+
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        Assert.That(html, Does.Contain("<td><code>Code block</code></td>"));
     }
 }

--- a/src/Markdig/Extensions/Tables/PipeTableParser.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableParser.cs
@@ -47,6 +47,16 @@ public class PipeTableParser : InlineParser, IPostInlineProcessor
             return false;
         }
 
+        // Do not treat pipe characters that occur within inline code block as table delimiters
+        // This handles the scenario where we start an inline code block but do a new line with a pipe
+        // `
+        // || Code ||
+        // `
+        if (processor.Inline != null && processor.Inline.ContainsParentOfType<CodeInline>())
+        {
+            return false;
+        }
+
         var c = slice.CurrentChar;
         var isNewLineFollowedByPipe = (c == '\n' || c == '\r') && slice.PeekChar() == '|';
 

--- a/src/Markdig/Helpers/HtmlHelper.cs
+++ b/src/Markdig/Helpers/HtmlHelper.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
-// This file is licensed under the BSD-Clause 2 license. 
+// This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
 using System.Diagnostics;
@@ -430,7 +430,7 @@ public static class HtmlHelper
 
         const string EndOfComment = "-->";
 
-        int endOfComment = slice.IndexOf(EndOfComment, StringComparison.Ordinal);
+        int endOfComment = slice.IndexOf(EndOfComment.AsSpan(), StringComparison.Ordinal);
         if (endOfComment < 0)
         {
             return false;
@@ -474,7 +474,7 @@ public static class HtmlHelper
     public static string Unescape(string? text, bool removeBackSlash = true)
     {
         // Credits: code from CommonMark.NET
-        // Copyright (c) 2014, Kārlis Gaņģis All rights reserved. 
+        // Copyright (c) 2014, Kārlis Gaņģis All rights reserved.
         // See license for details:  https://github.com/Knagis/CommonMark.NET/blob/master/LICENSE.md
         if (string.IsNullOrEmpty(text))
         {
@@ -553,7 +553,7 @@ public static class HtmlHelper
     public static int ScanEntity<T>(T slice, out int numericEntity, out int namedEntityStart,  out int namedEntityLength) where T : ICharIterator
     {
         // Credits: code from CommonMark.NET
-        // Copyright (c) 2014, Kārlis Gaņģis All rights reserved. 
+        // Copyright (c) 2014, Kārlis Gaņģis All rights reserved.
         // See license for details:  https://github.com/Knagis/CommonMark.NET/blob/master/LICENSE.md
 
         numericEntity = 0;
@@ -568,7 +568,7 @@ public static class HtmlHelper
         var start = slice.Start;
         char c = slice.NextChar();
         int counter = 0;
-        
+
         if (c == '#')
         {
             c = slice.PeekChar();

--- a/src/Markdig/Parsers/Inlines/CodeInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/CodeInlineParser.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 
+using Markdig.Extensions.Tables;
 using Markdig.Helpers;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
@@ -91,8 +92,13 @@ public class CodeInlineParser : InlineParser
                 }
                 if (whitespace < lookAhead.Length && lookAhead[whitespace] == '|')
                 {
-                    slice.Start = openingStart;
-                    return false;
+                    // Mirror the guard in PipeTableParser: if the next line starts with a pipe while we are inside
+                    // a table delimiter, defer to the pipe table parser so the backtick span stays intact.
+                    if (processor.Inline != null && processor.Inline.ContainsParentOfType<PipeTableDelimiterInline>())
+                    {
+                        slice.Start = openingStart;
+                        return false;
+                    }
                 }
 
                 containsNewLines = true;


### PR DESCRIPTION
Based on feedback from PR #891 - this PR fixes inline code block that spans multiple lines.

```
`
|| hidden text ||
`
```

