### PR TITLE
Fix AbbreviationExtension corrupting emphasis/bold/italic resolution (#935)

### DIFF
--- a/src/Markdig.Tests/Specs/AbbreviationSpecs.generated.cs
+++ b/src/Markdig.Tests/Specs/AbbreviationSpecs.generated.cs
@@ -220,5 +220,59 @@ namespace Markdig.Tests.Specs.Abbreviations
 
             TestParser.TestSpec("*[Foo]: foo\n*[Foo Bar]: foobar\n\nFoo B", "<p><abbr title=\"foo\">Foo</abbr> B</p>", "abbreviations|advanced", context: "Example 11\nSection Extensions / Abbreviation\n");
         }
+
+        // Abbreviation before emphasis on the same line should be resolved:
+        [Test]
+        public void ExtensionsAbbreviation_Example012()
+        {
+            // Example 12
+            // Section: Extensions / Abbreviation
+            //
+            // The following Markdown:
+            //     *[HTML]: HyperText Markup Language
+            //     
+            //     HTML supports **bold** and *italic*
+            //
+            // Should be rendered as:
+            //     <p><abbr title="HyperText Markup Language">HTML</abbr> supports <strong>bold</strong> and <em>italic</em></p>
+
+            TestParser.TestSpec("*[HTML]: HyperText Markup Language\n\nHTML supports **bold** and *italic*", "<p><abbr title=\"HyperText Markup Language\">HTML</abbr> supports <strong>bold</strong> and <em>italic</em></p>", "abbreviations|advanced", context: "Example 12\nSection Extensions / Abbreviation\n");
+        }
+
+        // Abbreviation inside emphasis should be resolved:
+        [Test]
+        public void ExtensionsAbbreviation_Example013()
+        {
+            // Example 13
+            // Section: Extensions / Abbreviation
+            //
+            // The following Markdown:
+            //     *[HTML]: HyperText Markup Language
+            //     
+            //     **HTML is great**
+            //
+            // Should be rendered as:
+            //     <p><strong><abbr title="HyperText Markup Language">HTML</abbr> is great</strong></p>
+
+            TestParser.TestSpec("*[HTML]: HyperText Markup Language\n\n**HTML is great**", "<p><strong><abbr title=\"HyperText Markup Language\">HTML</abbr> is great</strong></p>", "abbreviations|advanced", context: "Example 13\nSection Extensions / Abbreviation\n");
+        }
+
+        // Abbreviation both before and inside emphasis on the same line should be resolved:
+        [Test]
+        public void ExtensionsAbbreviation_Example014()
+        {
+            // Example 14
+            // Section: Extensions / Abbreviation
+            //
+            // The following Markdown:
+            //     *[HTML]: HyperText Markup Language
+            //     
+            //     HTML supports **bold** and **HTML too**
+            //
+            // Should be rendered as:
+            //     <p><abbr title="HyperText Markup Language">HTML</abbr> supports <strong>bold</strong> and <strong><abbr title="HyperText Markup Language">HTML</abbr> too</strong></p>
+
+            TestParser.TestSpec("*[HTML]: HyperText Markup Language\n\nHTML supports **bold** and **HTML too**", "<p><abbr title=\"HyperText Markup Language\">HTML</abbr> supports <strong>bold</strong> and <strong><abbr title=\"HyperText Markup Language\">HTML</abbr> too</strong></p>", "abbreviations|advanced", context: "Example 14\nSection Extensions / Abbreviation\n");
+        }
     }
 }

--- a/src/Markdig.Tests/Specs/AbbreviationSpecs.md
+++ b/src/Markdig.Tests/Specs/AbbreviationSpecs.md
@@ -119,3 +119,33 @@ Foo B
 .
 <p><abbr title="foo">Foo</abbr> B</p>
 ````````````````````````````````
+
+Abbreviation before emphasis on the same line should be resolved:
+
+```````````````````````````````` example
+*[HTML]: HyperText Markup Language
+
+HTML supports **bold** and *italic*
+.
+<p><abbr title="HyperText Markup Language">HTML</abbr> supports <strong>bold</strong> and <em>italic</em></p>
+````````````````````````````````
+
+Abbreviation inside emphasis should be resolved:
+
+```````````````````````````````` example
+*[HTML]: HyperText Markup Language
+
+**HTML is great**
+.
+<p><strong><abbr title="HyperText Markup Language">HTML</abbr> is great</strong></p>
+````````````````````````````````
+
+Abbreviation both before and inside emphasis on the same line should be resolved:
+
+```````````````````````````````` example
+*[HTML]: HyperText Markup Language
+
+HTML supports **bold** and **HTML too**
+.
+<p><abbr title="HyperText Markup Language">HTML</abbr> supports <strong>bold</strong> and <strong><abbr title="HyperText Markup Language">HTML</abbr> too</strong></p>
+````````````````````````````````

--- a/src/Markdig.Tests/TestSourcePosition.cs
+++ b/src/Markdig.Tests/TestSourcePosition.cs
@@ -535,13 +535,11 @@ literal      ( 1, 6)  8-9
     {
         Check("*[HTML]: Hypertext Markup Language\r\n\r\nLater in a text we are using HTML and it becomes an abbr tag HTML\r\n\r\nHTML abbreviation at the beginning of a line", @"
 paragraph    ( 2, 0) 38-102
-container    ( 2, 0) 38-102
 literal      ( 2, 0) 38-66
 abbreviation ( 2,29) 67-70
 literal      ( 2,33) 71-98
 abbreviation ( 2,61) 99-102
 paragraph    ( 4, 0) 107-150
-container    ( 4, 0) 107-150
 abbreviation ( 4, 0) 107-110
 literal      ( 4, 4) 111-150
 ", "abbreviations");

--- a/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
+++ b/src/Markdig/Extensions/Abbreviations/AbbreviationParser.cs
@@ -67,14 +67,14 @@ public class AbbreviationParser : BlockParser
         };
         if (!processor.Document.HasAbbreviations())
         {
-            processor.Document.ProcessInlinesBegin += DocumentOnProcessInlinesBegin;
+            processor.Document.ProcessInlinesEnd += DocumentOnProcessInlinesEnd;
         }
         processor.Document.AddAbbreviation(abbr.Label, abbr);
 
         return BlockState.BreakDiscard;
     }
 
-    private void DocumentOnProcessInlinesBegin(InlineProcessor inlineProcessor, Inline? inline)
+    private void DocumentOnProcessInlinesEnd(InlineProcessor inlineProcessor, Inline? inline)
     {
         var abbreviations = inlineProcessor.Document.GetAbbreviations();
         // Should not happen, but another extension could decide to remove them, so...
@@ -86,113 +86,151 @@ public class AbbreviationParser : BlockParser
         // Build a text matcher from the abbreviations labels
         var prefixTree = new CompactPrefixTree<Abbreviation>(abbreviations);
 
-        inlineProcessor.LiteralInlineParser.PostMatch += (InlineProcessor processor, ref StringSlice slice) =>
+        // Allocate the traversal stack once and reuse it across all leaf blocks.
+        var stack = new Stack<ContainerInline>();
+
+        foreach (var leaf in inlineProcessor.Document.Descendants<LeafBlock>())
         {
-            var literal = (LiteralInline)processor.Inline!;
-            var originalLiteral = literal;
-            var originalSpanEnd = literal.Span.End;
-
-            ContainerInline? container = null;
-
-            // This is slow, but we don't have much the choice
-            var content = literal.Content;
-            var text = content.Text;
-
-            for (int i = content.Start; i <= content.End; i++)
+            if (leaf.Inline is not null)
             {
-                // Abbreviation must be a whole word == start at the start of a line or after a whitespace
-                if (i != 0)
+                SubstituteInlineTree(leaf.Inline, prefixTree, stack);
+            }
+        }
+    }
+
+    private static void SubstituteInlineTree(
+        ContainerInline root,
+        CompactPrefixTree<Abbreviation> prefixTree,
+        Stack<ContainerInline> stack)
+    {
+        stack.Push(root);
+
+        while (stack.Count > 0)
+        {
+            var container = stack.Pop();
+            var child = container.FirstChild;
+            while (child != null)
+            {
+                var next = child.NextSibling;
+                if (child is LiteralInline literal)
                 {
-                    for (i = i - 1; i <= content.End; i++)
+                    SubstituteInLiteral(literal, prefixTree);
+                }
+                else if (child is ContainerInline childContainer)
+                {
+                    stack.Push(childContainer);
+                }
+                child = next;
+            }
+        }
+    }
+
+    private static void SubstituteInLiteral(LiteralInline literal, CompactPrefixTree<Abbreviation> prefixTree)
+    {
+        var content = literal.Content;
+        var text = content.Text;
+        var parent = literal.Parent;
+
+        // Nothing to do if this literal has no parent to insert siblings into
+        if (parent is null)
+        {
+            return;
+        }
+
+        // Save original span end before any mutations: on the first substitution
+        // currentLiteral IS literal, so currentLiteral.Span.End = abbrSpanStart - 1
+        // would corrupt literal.Span.End, which we need for remaining-literal calculations.
+        var originalSpanEnd = literal.Span.End;
+
+        // The "current" literal we're truncating as we find abbreviations.
+        // We start with the original literal — it stays in place and we insert after it.
+        var currentLiteral = literal;
+
+        for (int i = content.Start; i <= content.End; i++)
+        {
+            // Abbreviation must start at the beginning of the content or after whitespace
+            if (i != content.Start)
+            {
+                // Find the next whitespace-separated word start
+                for (i = i - 1; i <= content.End; i++)
+                {
+                    if (text[i].IsWhitespace())
                     {
-                        if (text[i].IsWhitespace())
-                        {
-                            i++;
-                            goto ValidAbbreviationStart;
-                        }
+                        i++;
+                        goto ValidAbbreviationStart;
                     }
-                    break;
+                }
+                break;
+            }
+
+        ValidAbbreviationStart:;
+
+            if (prefixTree.TryMatchLongest(text.AsSpan(i, content.End - i + 1), out KeyValuePair<string, Abbreviation> abbreviationMatch))
+            {
+                var match = abbreviationMatch.Key;
+                if (!IsValidAbbreviationEnding(match, content, i))
+                {
+                    continue;
                 }
 
-            ValidAbbreviationStart:;
+                var indexAfterMatch = i + match.Length;
 
-                if (prefixTree.TryMatchLongest(text.AsSpan(i, content.End - i + 1), out KeyValuePair<string, Abbreviation> abbreviationMatch))
+                // Compute source position from the original literal's own span/line/column.
+                // We use literal.Content.Start (the ORIGINAL literal parameter, never reassigned)
+                // because span positions are always relative to the start of the original literal.
+                // (InlineProcessor is not available post-parse; this is safe because
+                //  LiteralInlineParser never produces a literal spanning a line break.)
+                int charOffset = i - literal.Content.Start; // offset from original literal start
+                var abbrSpanStart = literal.Span.Start + charOffset;
+                var abbrInline = new AbbreviationInline(abbreviationMatch.Value)
                 {
-                    var match = abbreviationMatch.Key;
-                    if (!IsValidAbbreviationEnding(match, content, i))
+                    Span = new SourceSpan(abbrSpanStart, abbrSpanStart + match.Length - 1),
+                    Line = literal.Line,
+                    Column = literal.Column + charOffset,
+                };
+
+                // Truncate currentLiteral to end just before the abbreviation
+                currentLiteral.Content.End = i - 1;
+                currentLiteral.Span.End = abbrSpanStart - 1;
+
+                // Insert abbreviation after currentLiteral
+                currentLiteral.InsertAfter(abbrInline);
+
+                // If the truncated literal is now empty (abbreviation was at the very start
+                // of its content), remove it so it doesn't litter the tree.
+                if (currentLiteral.Content.End < currentLiteral.Content.Start)
+                {
+                    currentLiteral.Remove();
+                }
+
+                // If there is remaining text after the abbreviation, create a new literal for it
+                if (indexAfterMatch <= content.End)
+                {
+                    var remainingContent = content;
+                    remainingContent.Start = indexAfterMatch;
+
+                    var remainingLiteral = new LiteralInline
                     {
-                        continue;
-                    }
-
-                    var indexAfterMatch = i + match.Length;
-
-                    // If we don't have a container, create a new one
-                    if (container is null)
-                    {
-                        container = literal.Parent ??
-                            new ContainerInline
-                            {
-                                Span = originalLiteral.Span,
-                                Line = originalLiteral.Line,
-                                Column = originalLiteral.Column,
-                            };
-                    }
-
-                    var abbrInline = new AbbreviationInline(abbreviationMatch.Value)
-                    {
-                        Span =
-                        {
-                            Start = processor.GetSourcePosition(i, out int line, out int column),
-                        },
-                        Line = line,
-                        Column = column
-                    };
-                    abbrInline.Span.End = abbrInline.Span.Start + match.Length - 1;
-
-                    // Append the previous literal
-                    if (i > content.Start && literal.Parent is null)
-                    {
-                        container.AppendChild(literal);
-                    }
-
-                    literal.Span.End = abbrInline.Span.Start - 1;
-                    // Truncate it before the abbreviation
-                    literal.Content.End = i - 1;
-
-
-                    // Append the abbreviation
-                    container.AppendChild(abbrInline);
-
-                    // If this is the end of the string, clear the literal and exit
-                    if (content.End == indexAfterMatch - 1)
-                    {
-                        literal = null;
-                        break;
-                    }
-
-                    // Process the remaining literal
-                    literal = new LiteralInline()
-                    {
+                        Content = remainingContent,
                         Span = new SourceSpan(abbrInline.Span.End + 1, originalSpanEnd),
-                        Line = line,
-                        Column = column + match.Length,
+                        Line = literal.Line,
+                        Column = literal.Column + (indexAfterMatch - literal.Content.Start),
                     };
-                    content.Start = indexAfterMatch;
-                    literal.Content = content;
+                    abbrInline.InsertAfter(remainingLiteral);
 
+                    // Continue scanning from the new literal
+                    currentLiteral = remainingLiteral;
+                    // Update content reference so the loop bounds are correct
+                    content = remainingContent;
                     i = indexAfterMatch - 1;
                 }
-            }
-
-            if (container != null)
-            {
-                if (literal != null)
+                else
                 {
-                    container.AppendChild(literal);
+                    // No text left — stop
+                    break;
                 }
-                processor.Inline = container;
             }
-        };
+        }
     }
 
     private static bool IsValidAbbreviationEnding(string match, StringSlice content, int matchIndex)


### PR DESCRIPTION
Closes #935

## Summary

`AbbreviationParser` subscribed to `LiteralInlineParser.PostMatch` to perform abbreviation substitution *during* inline parsing, before emphasis delimiters were resolved. This caused two bugs:

- Abbreviations before emphasis on the same line left `**`/`*` as literal text instead of resolving them.
- Abbreviations inside emphasis (e.g. `**HTML is great**`) were silently dropped due to an off-by-one in the word-boundary guard (`i != 0` instead of `i != content.Start`).

The fix moves substitution to `document.ProcessInlinesEnd`, so it runs after the full inline tree — including emphasis and links — has been resolved. Abbreviations are inserted as direct siblings into each parent container rather than wrapped in an intermediate `ContainerInline`.

## Testing

Three new spec examples cover the two bugs and their combination. All 3 764 existing tests pass.

## Performance

Benchmarks run on .NET 10 / Intel Core i3-10110U. "Before" = `upstream/main` (old `PostMatch` approach); "after" = this PR.

| Scenario | Before (mean) | After (mean) | Δ time | Before alloc | After alloc | Δ alloc |
|---|---:|---:|---:|---:|---:|---:|
| 2 defs, 10 paragraphs | 9.743 µs | 8.260 µs | **−15 %** | 8.19 KB | 8.14 KB | −1 % |
| 2 defs, 200 paragraphs | 157.1 µs | 141.4 µs | **−10 %** | 124.0 KB | 119.6 KB | −4 % |
| 10 defs, 10 paragraphs | 14.41 µs | 13.41 µs | **−7 %** | 16.81 KB | 16.34 KB | −3 % |
| 10 defs, 200 paragraphs | 243.9 µs | 222.8 µs | **−9 %** | 247.7 KB | 234.7 KB | **−5 %** |
| Defs present, no matches, 200 paragraphs | 126.8 µs | 125.1 µs | −1 % (noise) | 78.7 KB | 82.9 KB | +5 % |

Key gains come from eliminating `processor.GetSourcePosition()` (a binary search per match, now replaced by O(1) arithmetic) and removing the `ContainerInline` wrapper allocation per matched literal. The slight allocation uptick in the no-matches case is from the `Stack<Block>` used by `document.Descendants<LeafBlock>()`, which fires even when nothing is substituted; this is within noise for real documents.