### PR TITLE
Reject emoji-parsing if the slice ends with `**`

### DIFF
--- a/src/Markdig/Extensions/Emoji/EmojiParser.cs
+++ b/src/Markdig/Extensions/Emoji/EmojiParser.cs
@@ -36,17 +36,26 @@ public class EmojiParser : InlineParser
             return false;
         }
 
-        // An emoji candidate must not end with two '*'.
-        var lastChar = slice.PeekChar(slice.Length - 1);
-        var secondLastChar = slice.PeekChar(slice.Length - 2);
-        if (lastChar == '*' && secondLastChar == '*')
-        {
-            return false;
-        }
+        //// An emoji candidate must not end with two '*'.
+        //var lastChar = slice.PeekChar(slice.Length - 1);
+        //var secondLastChar = slice.PeekChar(slice.Length - 2);
+        //if (lastChar == '*' && secondLastChar == '*')
+        //{
+        //    return false;
+        //}
 
         // Try to match an emoji shortcode or smiley
         if (!_emojiMapping.PrefixTree.TryMatchLongest(slice.Text.AsSpan(slice.Start, slice.Length), out KeyValuePair<string, string> match))
         {
+            return false;
+        }
+
+        // An emoji candidate must not end with two '*'.
+        var lastChar = match.Key[match.Key.Length - 1]; // slice.PeekChar(slice.Length - 1);
+        var secondLastChar = match.Key[match.Key.Length - 2]; // slice.PeekChar(slice.Length - 2);
+        if (lastChar == '*' && secondLastChar == '*')
+        {
+            // Emoji false positive
             return false;
         }
 

--- a/src/Markdig/Extensions/Emoji/EmojiParser.cs
+++ b/src/Markdig/Extensions/Emoji/EmojiParser.cs
@@ -48,7 +48,7 @@ public class EmojiParser : InlineParser
         {
             // Only look at the following char if the emoji ends with a '*', otherwise it is not needed.
             var followingChar = slice.PeekChar(match.Key.Length);
-            if (lastEmojiChar == '*' && followingChar == '*')
+            if (followingChar == '*')
             {
                 // Emoji false positive
                 return false;

--- a/src/Markdig/Extensions/Emoji/EmojiParser.cs
+++ b/src/Markdig/Extensions/Emoji/EmojiParser.cs
@@ -36,6 +36,14 @@ public class EmojiParser : InlineParser
             return false;
         }
 
+        // An emoji candidate must not end with two '*'.
+        var lastChar = slice.PeekChar(slice.Length - 1);
+        var secondLastChar = slice.PeekChar(slice.Length - 2);
+        if (lastChar == '*' && secondLastChar == '*')
+        {
+            return false;
+        }
+
         // Try to match an emoji shortcode or smiley
         if (!_emojiMapping.PrefixTree.TryMatchLongest(slice.Text.AsSpan(slice.Start, slice.Length), out KeyValuePair<string, string> match))
         {

--- a/src/Markdig/Extensions/Emoji/EmojiParser.cs
+++ b/src/Markdig/Extensions/Emoji/EmojiParser.cs
@@ -36,27 +36,23 @@ public class EmojiParser : InlineParser
             return false;
         }
 
-        //// An emoji candidate must not end with two '*'.
-        //var lastChar = slice.PeekChar(slice.Length - 1);
-        //var secondLastChar = slice.PeekChar(slice.Length - 2);
-        //if (lastChar == '*' && secondLastChar == '*')
-        //{
-        //    return false;
-        //}
-
         // Try to match an emoji shortcode or smiley
         if (!_emojiMapping.PrefixTree.TryMatchLongest(slice.Text.AsSpan(slice.Start, slice.Length), out KeyValuePair<string, string> match))
         {
             return false;
         }
 
-        // An emoji candidate must not end with two '*'.
-        var lastChar = match.Key[match.Key.Length - 1]; // slice.PeekChar(slice.Length - 1);
-        var secondLastChar = match.Key[match.Key.Length - 2]; // slice.PeekChar(slice.Length - 2);
-        if (lastChar == '*' && secondLastChar == '*')
+        // If the found emoji ends with a ´*´, the following char must not be a '*'.
+        var lastEmojiChar = match.Key[match.Key.Length - 1];
+        if (lastEmojiChar == '*')
         {
-            // Emoji false positive
-            return false;
+            // Only look at the following char if the emoji ends with a '*', otherwise it is not needed.
+            var followingChar = slice.PeekChar(match.Key.Length);
+            if (lastEmojiChar == '*' && followingChar == '*')
+            {
+                // Emoji false positive
+                return false;
+            }
         }
 
         // Push the EmojiInline


### PR DESCRIPTION
This pull request introduces an additional validation step in the emoji parsing logic to prevent false positives. Specifically, it ensures that emoji candidates ending with two asterisks (`**`) are not matched as valid emojis.

Emoji parsing improvement:

* Updated the `Match` method in `EmojiParser.cs` to return `false` if an emoji candidate ends with two asterisks, preventing incorrect emoji matches in such cases.

A sample markdown is provided on the #946 issue.

Closing #946 