### PR TITLE
Fix heading auto-link hijacking nested link labels (#668)

### DIFF
--- a/src/Markdig.Tests/TestAutoLinks.cs
+++ b/src/Markdig.Tests/TestAutoLinks.cs
@@ -21,4 +21,28 @@ public class TestAutoLinks
 
         Assert.That(html, Is.EqualTo(expected).IgnoreWhiteSpace);
     }
+
+    // https://github.com/xoofx/markdig/issues/668
+    // A heading's implicit reference must not resolve inside another still-open
+    // link bracket, which would break the outer link.
+    [Test]
+    public void TestAutoIdentifierHeadingLinkDoesNotHijackNestedLinkLabel()
+    {
+        var markdown = "# Testing Markdown\n\n" +
+                        "### Header\n\n" +
+                        "[Testing [Header]](https://www.bing.com)\n\n" +
+                        "[Testing [test]](https://www.google.com)\n";
+        var expected = "<h1 id=\"testing-markdown\">Testing Markdown</h1>\n" +
+                        "<h3 id=\"header\">Header</h3>\n" +
+                        "<p><a href=\"https://www.bing.com\">Testing [Header]</a></p>\n" +
+                        "<p><a href=\"https://www.google.com\">Testing [test]</a></p>";
+
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseAutoLinks()
+            .UseAutoIdentifiers()
+            .Build();
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        Assert.That(html, Is.EqualTo(expected).IgnoreWhiteSpace);
+    }
 }

--- a/src/Markdig/Extensions/AutoIdentifiers/HeadingLinkReferenceDefinition.cs
+++ b/src/Markdig/Extensions/AutoIdentifiers/HeadingLinkReferenceDefinition.cs
@@ -24,4 +24,11 @@ public class HeadingLinkReferenceDefinition : LinkReferenceDefinition
     /// Gets or sets the heading related to this link reference definition.
     /// </summary>
     public HeadingBlock Heading { get; set; }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Created implicitly for every heading, so it must not resolve inside another
+    /// still-open link bracket, e.g. <c>[Some text [Heading]](url)</c>.
+    /// </remarks>
+    internal override bool AllowResolutionInsideOpenLink => false;
 }

--- a/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/LinkInlineParser.cs
@@ -150,6 +150,13 @@ public class LinkInlineParser : InlineParser
             return false;
         }
 
+        // An implicit definition must not hijack a bracket nested inside a
+        // still-open link, which would break the outer one.
+        if (!linkRef.AllowResolutionInsideOpenLink && HasActiveAncestorLink(parent))
+        {
+            return false;
+        }
+
         Inline? link = null;
         // Try to use a callback directly defined on the LinkReferenceDefinition
         if (linkRef.CreateLinkInline != null)
@@ -428,6 +435,24 @@ public class LinkInlineParser : InlineParser
 
             return null;
         }
+    }
+
+    /// <summary>
+    /// Determines whether the delimiter is nested inside another link/image
+    /// delimiter that may still resolve.
+    /// </summary>
+    private static bool HasActiveAncestorLink(LinkDelimiterInline delimiter)
+    {
+        var inline = delimiter.Parent;
+        while (inline != null)
+        {
+            if (inline is LinkDelimiterInline { IsActive: true })
+            {
+                return true;
+            }
+            inline = inline.Parent;
+        }
+        return false;
     }
 
     private static void MarkParentAsInactive(Inline? inline)

--- a/src/Markdig/Syntax/LinkReferenceDefinition.cs
+++ b/src/Markdig/Syntax/LinkReferenceDefinition.cs
@@ -137,6 +137,16 @@ public class LinkReferenceDefinition : LeafBlock
     public CreateLinkInlineDelegate? CreateLinkInline { get; set; }
 
     /// <summary>
+    /// Gets whether this definition may resolve into a link while its label is
+    /// nested inside another still-open link or image bracket.
+    /// </summary>
+    /// <remarks>
+    /// <c>true</c> for user-authored definitions, preserving CommonMark's "links
+    /// cannot contain links". Implicitly generated ones override it to <c>false</c>.
+    /// </remarks>
+    internal virtual bool AllowResolutionInsideOpenLink => true;
+
+    /// <summary>
     /// Tries to the parse the specified text into a definition.
     /// </summary>
     /// <typeparam name="T">Type of the text</typeparam>


### PR DESCRIPTION

## Problem

https://github.com/xoofx/markdig/issues/668

When both the `AutoLinks` and `AutoIdentifiers` extensions are enabled, a Markdown link whose label
contains a nested `[...]` fragment that happens to match the text of an existing heading gets parsed
incorrectly. Example:

## Header

[Testing [Header]](https://www.bing.com)

[Testing [test]](https://www.google.com)
```

Expected (matches the output produced when only `AutoLinks` is enabled):

```html
<h1 id="testing-markdown">Testing Markdown</h1>
<h3 id="header">Header</h3>
<p><a href="https://www.bing.com">Testing [Header]</a></p>
<p><a href="https://www.google.com">Testing [test]</a></p>
```

Actual (on `upstream/main`, commit `b07b98e1`):

```html
<h1 id="testing-markdown">Testing Markdown</h1>
<h3 id="header">Header</h3>
<p>[Testing <a href="#header">Header</a>](<a href="https://www.bing.com">https://www.bing.com</a>)</p>
<p><a href="https://www.google.com">Testing [test]</a></p>
```

## Root cause

`AutoIdentifierExtension` (`src/Markdig/Extensions/AutoIdentifiers/AutoIdentifierExtension.cs`), when
its default `AutoLink` option is enabled (it is on by default via `AutoIdentifierOptions.Default`),
registers a `HeadingLinkReferenceDefinition` at the document level for every heading, keyed by the
heading's raw text. This turns any occurrence of `[HeadingText]` in the document into an implicit
shortcut reference link to that heading, without the author ever writing a `[HeadingText]: url`
reference definition.

Markdig's core link parser (`src/Markdig/Parsers/Inlines/LinkInlineParser.cs`) resolves brackets using
the CommonMark "nearest active opener wins" algorithm: when it hits the `]` right after `Header`, it
looks for a link reference definition matching `Header` first. Because the heading `### Header`
implicitly registered one, the inner `[Header]` resolves into a link before the outer bracket ever gets
a chance to see its own `](https://www.bing.com)`. Per CommonMark's "links cannot contain links" rule,
successfully resolving the inner link also deactivates the outer `[` bracket, so the outer bracket can
no longer become a link and is emitted as literal text instead.

This exact resolution order is correct and spec-compliant for a reference definition the author defined
on purpose (verified: a plain CommonMark document containing an explicit `[Header]: /somewhere`
definition produces the identical "broken-looking" nesting, with no extensions involved at all). The bug
is that `AutoIdentifierExtension`'s heading auto-link references are created *implicitly*, for every
heading, with no way for the author to know that a particular word will silently start behaving as a
link reference elsewhere in the document — including inside brackets that were never meant to be link
labels for the heading, such as the label of a larger, still-open link.

## Fix

Added an internal extensibility point, `LinkReferenceDefinition.AllowResolutionInsideOpenLink` (default
`true`), and overrode it to `false` on `HeadingLinkReferenceDefinition`
(`src/Markdig/Extensions/AutoIdentifiers/HeadingLinkReferenceDefinition.cs`). In
`LinkInlineParser.ProcessLinkReference`, before resolving a shortcut/collapsed/full reference link, the
parser now checks whether the reference definition disallows resolution while nested inside another
still-open, active link/image bracket (`LinkInlineParser.HasActiveAncestorLink`). If so, resolution is
skipped and the normal CommonMark fallback (treat the inner bracket as literal text, let the outer
bracket complete) takes over, exactly as it already does for any word that doesn't match a heading.

This is scoped narrowly to implicitly generated heading references:
- Regular, user-authored reference definitions (`[label]: url`) are completely unaffected -
  `AllowResolutionInsideOpenLink` defaults to `true`, preserving existing CommonMark-compliant behavior
  for nested brackets with explicit reference definitions.
- Standalone heading auto-links (not nested inside another link), e.g. `See [Header] for details.`,
  continue to work exactly as before.
- Footnote reference definitions and any other extension using `LinkReferenceDefinition` are unaffected.

## With the fix (full suite)

(The single skip, `ListUnorderedLooseTop`, is pre-existing and unrelated to this change - present before
this fix as well.)
