### PR TITLE
Fix: keep trailing content out of an unmatched emphasis closer (#743)

### DIFF
--- a/src/Markdig.Tests/TestEmphasisRoundtrip.cs
+++ b/src/Markdig.Tests/TestEmphasisRoundtrip.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+using Markdig.Renderers.Roundtrip;
+using Markdig.Syntax;
+
+namespace Markdig.Tests;
+
+[TestFixture]
+public class TestEmphasisRoundtrip
+{
+    private static string RoundTrip(string markdown, MarkdownPipeline pipeline)
+    {
+        MarkdownDocument document = Markdown.Parse(markdown, pipeline);
+        var writer = new StringWriter();
+        var renderer = new RoundtripRenderer(writer);
+        pipeline.Setup(renderer);
+        renderer.Write(document);
+        return writer.ToString();
+    }
+
+    // Leftover delimiter characters below the minimum count used to stay nested
+    // inside the emphasis they closed, moving the following text to the end of
+    // the block. https://github.com/xoofx/markdig/issues/743
+    [Test]
+    public void GridTableSeparatorRoundtripsWithTrackTrivia()
+    {
+        string markdown =
+            "+---------------+---------------+--------------------+\n" +
+            "| Fruit         | Price         | Advantages         |\n" +
+            "+===============+===============+====================+\n" +
+            "| Bananas       | first line    | first line         |\n" +
+            "|               | next line     | next line          |\n" +
+            "+---------------+---------------+--------------------+\n";
+
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseAutoLinks()
+            .UseEmphasisExtras()
+            .UseListExtras()
+            .EnableTrackTrivia()
+            .Build();
+
+        Assert.That(RoundTrip(markdown, pipeline), Is.EqualTo(markdown));
+    }
+
+    // Same defect, minimal: leftovers (15 = 7 * 2 + 1) below the "==" minimum.
+    [Test]
+    public void UnbalancedMarkedRunsRoundtrip()
+    {
+        string markdown = "+===============+===============+\n";
+
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseEmphasisExtras()
+            .EnableTrackTrivia()
+            .Build();
+
+        Assert.That(RoundTrip(markdown, pipeline), Is.EqualTo(markdown));
+    }
+
+    // The fix must not prevent balanced "marked" emphasis from being detected.
+    [Test]
+    public void BalancedMarkedEmphasisStillParses()
+    {
+        var pipeline = new MarkdownPipelineBuilder().UseEmphasisExtras().Build();
+        Assert.That(Markdown.ToHtml("==bold==", pipeline).Trim(), Is.EqualTo("<p><mark>bold</mark></p>"));
+    }
+}

--- a/src/Markdig/Parsers/Inlines/EmphasisInlineParser.cs
+++ b/src/Markdig/Parsers/Inlines/EmphasisInlineParser.cs
@@ -419,6 +419,19 @@ public class EmphasisInlineParser : InlineParser, IPostInlineProcessor
                         break;
                     }
                 }
+
+                // Leftover delimiter characters keep the following inlines nested inside
+                // the emphasis; move them out so they keep their original position.
+                if (closeDelimiter.DelimiterCount > 0 && closeDelimiter.Parent is EmphasisInline closerParentEmphasis)
+                {
+                    var outermostEmphasis = closerParentEmphasis;
+                    while (outermostEmphasis.Parent is EmphasisInline ancestorEmphasis)
+                    {
+                        outermostEmphasis = ancestorEmphasis;
+                    }
+
+                    closeDelimiter.MoveChildrenAfter(outermostEmphasis);
+                }
             }
         }
 


### PR DESCRIPTION

## Problem

Fixes https://github.com/xoofx/markdig/issues/743

## Problem

Since v28.0, parsing a grid-table-like block with `EnableTrackTrivia()` and then
rendering it back with `RoundtripRenderer` produces invalid output. The reported
input round-trips cleanly up to v27.0 but is corrupted from v28.0 onward:

Input:

```
+---------------+---------------+--------------------+
| Fruit         | Price         | Advantages         |
+===============+===============+====================+
| Bananas       | first line    | first line         |
|               | next line     | next line          |
+---------------+---------------+--------------------+
```

Corrupted round-trip output (the middle separator column collapses to a single
`=` and a stray run of `=` is appended after the last line):

```
+---------------+---------------+--------------------+
| Fruit         | Price         | Advantages         |
+===============+=+====================+
| Bananas       | first line    | first line         |
|               | next line     | next line          |
+---------------+---------------+--------------------+==============
```

## Root cause

The block is a plain paragraph (the reporter's pipeline does not enable grid
tables). The `+===...===+` separators are runs of `=`, which the EmphasisExtras
"marked" delimiter (`==`, minimum count 2) parses as emphasis.

`EmphasisInlineParser.ProcessEmphasis` matches an opener run against a closer run.
Each match embraces everything that follows the opener - including the closer and
every inline after it - and later moves the trailing content back out. That
"move out" step only runs when the closer is fully consumed (`DelimiterCount == 0`)
or when the opener is fully consumed. When both the opener and the closer keep
leftover delimiter characters that fall below the minimum count (e.g. a run of 15
`=` is 7 pairs plus one leftover), the trailing content stays nested inside the
innermost emphasis. The roundtrip renderer then writes the closing delimiters
after that trailing content, which pushes the closing run to the end of the block.

The regression was introduced by `Fix emphasis when EnableTrackTrivia() is used
(#561)`, which made emphasis detection work under trivia and thereby exposed this
pre-existing gap in the leftover-closer handling.

## Fix

After the matching loop for a closer, if the closer still holds leftover delimiter
characters and is nested inside the emphasis it closed, move the inlines that
follow the closer out to the outermost enclosing emphasis. This mirrors the
existing behaviour for a fully consumed opener. The leftover closer itself keeps
its position, so cases with no trailing content (already covered by
`TestEmphasisExtended`, e.g. `2223222` -> `2<two-only>32</two-only>`) are
unchanged.

One file changed: `src/Markdig/Parsers/Inlines/EmphasisInlineParser.cs`.

## Tests

Added `src/Markdig.Tests/TestEmphasisRoundtrip.cs`:

- `GridTableSeparatorRoundtripsWithTrackTrivia` - the exact issue input round-trips
  to itself.
- `UnbalancedMarkedRunsRoundtrip` - minimal reduction (`+===============+===============+`).
- `BalancedMarkedEmphasisStillParses` - `==bold==` still renders `<mark>bold</mark>`,
  confirming emphasis detection under EmphasisExtras is preserved.

The two round-trip tests fail before the fix and pass after it. The full test
suite passes (3798 passed, 1 pre-existing skip, 0 failed).
