### PR TITLE
Fix indent on first list item (#482)

### DIFF
--- a/src/Markdig.Tests/TestNormalize.cs
+++ b/src/Markdig.Tests/TestNormalize.cs
@@ -174,6 +174,25 @@ line3");
     }
 
     [Test]
+    public void ListUnorderedSingleLineNested()
+    {
+        AssertNormalizeNoTrim("- - a");
+    }
+
+    [Test]
+    public void ListUnorderedWithQuoteBlock()
+    {
+        AssertNormalizeNoTrim("- > p");
+    }
+
+    [Test]
+    public void ListUnorderedEmpty()
+    {
+        AssertNormalizeNoTrim("-", "- ");
+        AssertNormalizeNoTrim("- ");
+    }
+
+    [Test]
     public void ListOrderedLooseAndCodeBlock()
     {
         AssertNormalizeNoTrim(@"1. ```
@@ -238,6 +257,13 @@ line3");
     - Bar
 11. c
 12. c");
+    }
+
+    [Test]
+    public void ListOrderedEmpty()
+    {
+        AssertNormalizeNoTrim("1.", "1. ");
+        AssertNormalizeNoTrim("1. ");
     }
 
     [Test]

--- a/src/Markdig/Renderers/Normalize/ListRenderer.cs
+++ b/src/Markdig/Renderers/Normalize/ListRenderer.cs
@@ -38,12 +38,15 @@ public class ListRenderer : NormalizeObjectRenderer<ListBlock>
                 var item = listBlock[i];
                 var listItem = (ListItemBlock) item;
                 renderer.EnsureLine();
-
-                renderer.Write(index.ToString(CultureInfo.InvariantCulture));
-                renderer.Write(listBlock.OrderedDelimiter);
-                renderer.Write(' ');
-                renderer.PushIndent(new string(' ', IntLog10Fast(index) + 3));
-                renderer.WriteChildren(listItem);
+                renderer.PushHangingIndent($"{index.ToString(CultureInfo.InvariantCulture)}{listBlock.OrderedDelimiter} ");
+                if (listItem.Count == 0)
+                {
+                    renderer.Write(""); // trigger writing of indent
+                }
+                else
+                {
+                    renderer.WriteChildren(listItem);
+                }
                 renderer.PopIndent();
                 switch (listBlock.BulletType)
                 {
@@ -65,10 +68,15 @@ public class ListRenderer : NormalizeObjectRenderer<ListBlock>
                 var item = listBlock[i];
                 var listItem = (ListItemBlock) item;
                 renderer.EnsureLine();
-                renderer.Write(renderer.Options.ListItemCharacter ?? listBlock.BulletType);
-                renderer.Write(' ');
-                renderer.PushIndent("  ");
-                renderer.WriteChildren(listItem);
+                renderer.PushHangingIndent($"{renderer.Options.ListItemCharacter ?? listBlock.BulletType} ");
+                if (listItem.Count == 0)
+                {
+                    renderer.Write(""); // trigger writing of indent
+                }
+                else
+                {
+                    renderer.WriteChildren(listItem);
+                }
                 renderer.PopIndent();
                 if (i + 1 < listBlock.Count && listBlock.IsLoose)
                 {
@@ -81,16 +89,4 @@ public class ListRenderer : NormalizeObjectRenderer<ListBlock>
 
         renderer.FinishBlock(true);
     }
-
-
-    private static int IntLog10Fast(int input) =>
-        (input < 10) ? 0 :
-        (input < 100) ? 1 :
-        (input < 1000) ? 2 :
-        (input < 10000) ? 3 :
-        (input < 100000) ? 4 :
-        (input < 1000000) ? 5 :
-        (input < 10000000) ? 6 :
-        (input < 100000000) ? 7 :
-        (input < 1000000000) ? 8 : 9;
 }

--- a/src/Markdig/Renderers/TextRendererBase.cs
+++ b/src/Markdig/Renderers/TextRendererBase.cs
@@ -74,6 +74,7 @@ public abstract class TextRendererBase<T> : TextRendererBase where T : TextRende
     {
         private readonly string? _constant;
         private readonly string[]? _lineSpecific;
+        private readonly string? _marker;
         private int position;
 
         internal Indent(string constant)
@@ -86,8 +87,20 @@ public abstract class TextRendererBase<T> : TextRendererBase where T : TextRende
             _lineSpecific = lineSpecific;
         }
 
+        internal Indent(string marker, string rest)
+        {
+            _marker = marker;
+            _constant = rest;
+        }
+
         internal string Next()
         {
+            if (_marker != null && position == 0)
+            {
+                position++;
+                return _marker;
+            }
+
             if (_constant != null)
             {
                 return _constant;
@@ -181,6 +194,21 @@ public abstract class TextRendererBase<T> : TextRendererBase where T : TextRende
 
         // ensure that indents are written to the output stream
         // this assumes that calls after PushIndent wil write children content
+        previousWasLine = true;
+    }
+
+    /// <summary>
+    /// Pushes a hanging indent. Where the first line's indent is provided and
+    /// subsequent lines will be indented by the same amount with blank spaces
+    /// </summary>
+    /// <param name="marker">The first line of the hanging indent.</param>
+    public void PushHangingIndent(string marker)
+    {
+        if (marker is null) ThrowHelper.ArgumentNullException(nameof(marker));
+        indents.Add(new Indent(marker, new string(' ', marker.Length)));
+
+        // ensure that indents are written to the output stream
+        // this assumes that calls after PushHangingIndent will write children content
         previousWasLine = true;
     }
 


### PR DESCRIPTION
This PR fixes
- #482 (the issues I was originally looking at)
- #320 (the original report of the problem)

In short the `Markdig.Renderers.Normalize.ListRenderer` would include the text for the "list" part of the list item as text, and then push an `Indent` on the stack comprised on a string of spaces, and lastly then render all the children items.

This caused a problem when the first child block wanted to add its own `Indent` on the stack.  When that first item was a QuoteBlock, `previousWasLine` within `TextRendererBase` would still be false, causing its own indent to be "eaten" on the first line of the QuoteBlock.  As reported in the bug

```
- > p
```

Would get changed into

```
- p
```

At the same time if first child block was a sub list an extra new line would be inserted changing
```
- - a
```

Into
```
- 
  - a
```

To correct this problem, I used `Markdig.Renderers.Roundtrip.ListRenderer` as inspiration, and updated the Normalize version to move all of the "List" data into the `Indent`.  This did require creating a new constructor so that we could create `Indent`s that would have a specified "first line", and all subsequent uses of the `Indent` would yield a string the same width of the "first line", but made of spaces.  Additional a **_new public method was add_**, `PushHangingIndent` to allow pushing these new `Indent`s to the stack. 

This mostly addressed the problem.  However it created a problem for truly empty list items.  They had no children, and as a result `WriteChildren` would effectively be a no-op.  Again the Roundtrip version contains a solution, we detect this case and just write the empty string, which will respect the `Indent`.

There is one caveat with that, as noted in the two new tests `ListUnorderedEmpty` and `ListOrderedEmpty`.  With this implementation, the trailing space that follow the `OrderedDelimiter` or `BulletType` is always included, even if it's not in the input.  We could address this within our condition for the empty list, but I was not able to find a good way to detect the case when trailing space was in the input.  I assume it's better to add the space that will likely be required instead of eating it.  But that can easily be changed.