### PR TITLE
Add Normalization Support for PipeTables (GFM)

### DIFF
--- a/src/Markdig.Tests/TestNormalize.cs
+++ b/src/Markdig.Tests/TestNormalize.cs
@@ -461,11 +461,31 @@ This is a last line";
     [Test]
     public void PipeTables()
     {
-        AssertNormalizeNoTrim("Foo | Bar\n--- | ---\nHello | *World*", "| Foo | Bar |\n| --- | --- |\n| Hello | *World* |\n");
-        AssertNormalizeNoTrim("Foo | Bar\n:---: | ---:\nHello | *World*", "| Foo | Bar |\n| :---: | ---: |\n| Hello | *World* |\n");
-        AssertNormalizeNoTrim("| Foo |\n| --- |\n| Hello World |\n");
-        AssertNormalizeNoTrim("| Foo | Bar |\n| --- | --- |\n| Hello World | *World* |\n");
-        AssertNormalizeNoTrim("| Foo | Bar |\n| :--- | ---: |\n| Hello World | *World* |\n");
+        AssertNormalizeNoTrim(@"Foo | Bar
+--- | ---
+Hello | *World*",            @"| Foo | Bar |
+| --- | --- |
+| Hello | *World* |
+");
+        AssertNormalizeNoTrim(@"
+Foo | Bar
+:---: | ---:
+Hello | *World*",             @"| Foo | Bar |
+| :---: | ---: |
+| Hello | *World* |
+");
+        AssertNormalizeNoTrim(@"| Foo |
+| --- |
+| Hello World |
+");
+        AssertNormalizeNoTrim(@"| Foo | Bar |
+| --- | --- |
+| Hello World | *World* |
+");
+        AssertNormalizeNoTrim(@"| Foo | Bar |
+| :--- | ---: |
+| Hello World | *World* |
+");
     }
 
     private static void AssertSyntax(string expected, MarkdownObject syntax)

--- a/src/Markdig.Tests/TestNormalize.cs
+++ b/src/Markdig.Tests/TestNormalize.cs
@@ -461,9 +461,11 @@ This is a last line";
     [Test]
     public void PipeTables()
     {
-        AssertNormalizeNoTrim("| Foo | Bar |\n| :--- | ---: |\n| Hello World | *World* |");
+        AssertNormalizeNoTrim("Foo | Bar\n--- | ---\nHello | *World*", "| Foo | Bar |\n| --- | --- |\n| Hello | *World* |\n");
+        AssertNormalizeNoTrim("Foo | Bar\n:---: | ---:\nHello | *World*", "| Foo | Bar |\n| :---: | ---: |\n| Hello | *World* |\n");
         AssertNormalizeNoTrim("| Foo |\n| --- |\n| Hello World |\n");
         AssertNormalizeNoTrim("| Foo | Bar |\n| --- | --- |\n| Hello World | *World* |\n");
+        AssertNormalizeNoTrim("| Foo | Bar |\n| :--- | ---: |\n| Hello World | *World* |\n");
     }
 
     private static void AssertSyntax(string expected, MarkdownObject syntax)

--- a/src/Markdig.Tests/TestNormalize.cs
+++ b/src/Markdig.Tests/TestNormalize.cs
@@ -465,27 +465,32 @@ This is a last line";
 --- | ---
 Hello | *World*",            @"| Foo | Bar |
 | --- | --- |
-| Hello | *World* |
-");
+| Hello | *World* |");
         AssertNormalizeNoTrim(@"
 Foo | Bar
 :---: | ---:
 Hello | *World*",             @"| Foo | Bar |
 | :---: | ---: |
-| Hello | *World* |
-");
+| Hello | *World* |");
+        AssertNormalizeNoTrim(@"| Foo |
+| --- |
+| Hello World |");
+        AssertNormalizeNoTrim(@"| Foo | Bar |
+| --- | --- |
+| Hello World | *World* |");
+        AssertNormalizeNoTrim(@"| Foo | Bar |
+| :--- | ---: |
+| Hello World | *World* |");
+    }
+
+    [Test]
+    public void PipeTablesFollowedByText()
+    {
         AssertNormalizeNoTrim(@"| Foo |
 | --- |
 | Hello World |
-");
-        AssertNormalizeNoTrim(@"| Foo | Bar |
-| --- | --- |
-| Hello World | *World* |
-");
-        AssertNormalizeNoTrim(@"| Foo | Bar |
-| :--- | ---: |
-| Hello World | *World* |
-");
+
+Text following the table.");
     }
 
     private static void AssertSyntax(string expected, MarkdownObject syntax)

--- a/src/Markdig.Tests/TestNormalize.cs
+++ b/src/Markdig.Tests/TestNormalize.cs
@@ -458,6 +458,14 @@ This is a last line";
         AssertNormalizeNoTrim("Hello from mailto:hello@example.com", "Hello from mailto:hello@example.com", new NormalizeOptions() { ExpandAutoLinks = false, });
     }
 
+    [Test]
+    public void PipeTables()
+    {
+        AssertNormalizeNoTrim("| Foo | Bar |\n| :--- | ---: |\n| Hello World | *World* |");
+        AssertNormalizeNoTrim("| Foo |\n| --- |\n| Hello World |\n");
+        AssertNormalizeNoTrim("| Foo | Bar |\n| --- | --- |\n| Hello World | *World* |\n");
+    }
+
     private static void AssertSyntax(string expected, MarkdownObject syntax)
     {
         var writer = new StringWriter();
@@ -499,6 +507,7 @@ This is a last line";
             .UseAutoLinks()
             .UseJiraLinks(new Extensions.JiraLinks.JiraLinkOptions("https://jira.example.com"))
             .UseTaskLists()
+            .UsePipeTables()
             .Build();
 
         var result = Markdown.Normalize(input, options, pipeline: pipeline);

--- a/src/Markdig/Extensions/Tables/NormalizeTableRenderer.cs
+++ b/src/Markdig/Extensions/Tables/NormalizeTableRenderer.cs
@@ -1,0 +1,65 @@
+using Markdig.Renderers.Normalize;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Markdig.Extensions.Tables
+{
+    public class NormalizeTableRenderer : NormalizeObjectRenderer<Table>
+    {
+        public const string PipeSeparator = "|";
+        public const string HeaderSeparator = "---";
+        public const string AlignmentChar = ":";
+        public const string MarginSeparator = " ";
+        protected override void Write(NormalizeRenderer renderer, Table obj)
+        {
+            renderer.EnsureLine();
+
+            foreach (var row in obj.OfType<TableRow>())
+            {
+                renderer.Write(PipeSeparator);
+
+                foreach (var tableCell in row)
+                {
+                    renderer.Write(MarginSeparator);
+
+                    renderer.Render(tableCell);
+
+                    renderer.Write(MarginSeparator);
+                    renderer.Write(PipeSeparator);
+                }
+
+                renderer.WriteLine();
+
+
+                if (row.IsHeader)
+                {
+                    bool alignmentEnabled = obj.ColumnDefinitions.Any(c => c.Alignment != TableColumnAlign.Left);
+
+                    renderer.Write(PipeSeparator);
+
+                    foreach (var column in obj.ColumnDefinitions)
+                    {
+                        renderer.Write(MarginSeparator);
+                        if (alignmentEnabled && (column.Alignment == TableColumnAlign.Left || column.Alignment == TableColumnAlign.Center))
+                        {
+                            renderer.Write(AlignmentChar);
+                        }
+                        renderer.Write(HeaderSeparator);
+                        if (alignmentEnabled && (column.Alignment == TableColumnAlign.Right || column.Alignment == TableColumnAlign.Center))
+                        {
+                            renderer.Write(AlignmentChar);
+                        }
+                        renderer.Write(MarginSeparator);
+                        renderer.Write(PipeSeparator);
+                    }
+
+                    renderer.WriteLine();
+                }
+            }
+
+            renderer.FinishBlock(true);
+        }
+    }
+}

--- a/src/Markdig/Extensions/Tables/NormalizeTableRenderer.cs
+++ b/src/Markdig/Extensions/Tables/NormalizeTableRenderer.cs
@@ -1,65 +1,68 @@
-using Markdig.Renderers.Normalize;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using Markdig.Renderers.Normalize;
 
-namespace Markdig.Extensions.Tables
+namespace Markdig.Extensions.Tables;
+
+/// <summary>
+/// A Normalize renderer for a <see cref="Table"/> in normalized form.
+/// </summary>
+/// <seealso cref="NormalizeObjectRenderer{Table}" />
+public class NormalizeTableRenderer : NormalizeObjectRenderer<Table>
 {
-    public class NormalizeTableRenderer : NormalizeObjectRenderer<Table>
-    {
-        public const string PipeSeparator = "|";
-        public const string HeaderSeparator = "---";
-        public const string AlignmentChar = ":";
-        public const string MarginSeparator = " ";
-        protected override void Write(NormalizeRenderer renderer, Table obj)
-        {
-            renderer.EnsureLine();
+    private const string PipeSeparator = "|";
+    private const string HeaderSeparator = "---";
+    private const string AlignmentChar = ":";
+    private const string MarginSeparator = " ";
 
-            foreach (var row in obj.OfType<TableRow>())
+    /// <summary>
+    /// Writes the object to the specified renderer.
+    /// </summary>
+    protected override void Write(NormalizeRenderer renderer, Table obj)
+    {
+        renderer.EnsureLine();
+
+        foreach (var row in obj.OfType<TableRow>())
+        {
+            renderer.Write(PipeSeparator);
+
+            foreach (var tableCell in row)
             {
+                renderer.Write(MarginSeparator);
+
+                renderer.Render(tableCell);
+
+                renderer.Write(MarginSeparator);
+                renderer.Write(PipeSeparator);
+            }
+
+            renderer.WriteLine();
+
+            if (row.IsHeader)
+            {
+                bool alignmentEnabled = obj.ColumnDefinitions.Any(c => c.Alignment != TableColumnAlign.Left);
+
                 renderer.Write(PipeSeparator);
 
-                foreach (var tableCell in row)
+                foreach (var column in obj.ColumnDefinitions)
                 {
                     renderer.Write(MarginSeparator);
-
-                    renderer.Render(tableCell);
-
+                    if (alignmentEnabled && (column.Alignment == TableColumnAlign.Left || column.Alignment == TableColumnAlign.Center))
+                    {
+                        renderer.Write(AlignmentChar);
+                    }
+                    renderer.Write(HeaderSeparator);
+                    if (alignmentEnabled && (column.Alignment == TableColumnAlign.Right || column.Alignment == TableColumnAlign.Center))
+                    {
+                        renderer.Write(AlignmentChar);
+                    }
                     renderer.Write(MarginSeparator);
                     renderer.Write(PipeSeparator);
                 }
 
                 renderer.WriteLine();
-
-
-                if (row.IsHeader)
-                {
-                    bool alignmentEnabled = obj.ColumnDefinitions.Any(c => c.Alignment != TableColumnAlign.Left);
-
-                    renderer.Write(PipeSeparator);
-
-                    foreach (var column in obj.ColumnDefinitions)
-                    {
-                        renderer.Write(MarginSeparator);
-                        if (alignmentEnabled && (column.Alignment == TableColumnAlign.Left || column.Alignment == TableColumnAlign.Center))
-                        {
-                            renderer.Write(AlignmentChar);
-                        }
-                        renderer.Write(HeaderSeparator);
-                        if (alignmentEnabled && (column.Alignment == TableColumnAlign.Right || column.Alignment == TableColumnAlign.Center))
-                        {
-                            renderer.Write(AlignmentChar);
-                        }
-                        renderer.Write(MarginSeparator);
-                        renderer.Write(PipeSeparator);
-                    }
-
-                    renderer.WriteLine();
-                }
             }
-
-            renderer.FinishBlock(true);
         }
+
+        renderer.FinishBlock(true);
     }
 }

--- a/src/Markdig/Extensions/Tables/NormalizeTableRenderer.cs
+++ b/src/Markdig/Extensions/Tables/NormalizeTableRenderer.cs
@@ -21,8 +21,16 @@ public class NormalizeTableRenderer : NormalizeObjectRenderer<Table>
     {
         renderer.EnsureLine();
 
+        bool firstRow = true;
+
         foreach (var row in obj.OfType<TableRow>())
         {
+            if (!firstRow)
+            {
+                renderer.WriteLine();
+            }
+            firstRow = false;
+
             renderer.Write(PipeSeparator);
 
             foreach (var tableCell in row)
@@ -35,10 +43,10 @@ public class NormalizeTableRenderer : NormalizeObjectRenderer<Table>
                 renderer.Write(PipeSeparator);
             }
 
-            renderer.WriteLine();
-
             if (row.IsHeader)
             {
+                renderer.WriteLine();
+
                 bool alignmentEnabled = obj.ColumnDefinitions.Any(c => c.Alignment != TableColumnAlign.Left);
 
                 renderer.Write(PipeSeparator);
@@ -58,8 +66,6 @@ public class NormalizeTableRenderer : NormalizeObjectRenderer<Table>
                     renderer.Write(MarginSeparator);
                     renderer.Write(PipeSeparator);
                 }
-
-                renderer.WriteLine();
             }
         }
 

--- a/src/Markdig/Extensions/Tables/PipeTableExtension.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableExtension.cs
@@ -66,8 +66,7 @@ public class PipeTableExtension : IMarkdownExtension
             htmlRenderer.ObjectRenderers.Add(new HtmlTableRenderer());
         }
 
-        var normalizeRenderer = renderer as NormalizeRenderer;
-        if (normalizeRenderer != null)
+        if (renderer is NormalizeRenderer normalizeRenderer && !normalizeRenderer.ObjectRenderers.Contains<NormalizeTableRenderer>())
         {
             normalizeRenderer.ObjectRenderers.AddIfNotAlready<NormalizeTableRenderer>();
         }

--- a/src/Markdig/Extensions/Tables/PipeTableExtension.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableExtension.cs
@@ -53,12 +53,6 @@ public class PipeTableExtension : IMarkdownExtension
             {
                 pipeline.InlineParsers.InsertBefore<EmphasisInlineParser>(pipeTableParser);
             }
-            
-            var normalizeRenderer = renderer as NormalizeRenderer;
-            if (normalizeRenderer != null)
-            {
-                normalizeRenderer.ObjectRenderers.AddIfNotAlready<NormalizeTableRenderer>();
-            }
         }
     }
 
@@ -70,6 +64,12 @@ public class PipeTableExtension : IMarkdownExtension
         if (renderer is HtmlRenderer htmlRenderer && !htmlRenderer.ObjectRenderers.Contains<HtmlTableRenderer>())
         {
             htmlRenderer.ObjectRenderers.Add(new HtmlTableRenderer());
+        }
+
+        var normalizeRenderer = renderer as NormalizeRenderer;
+        if (normalizeRenderer != null)
+        {
+            normalizeRenderer.ObjectRenderers.AddIfNotAlready<NormalizeTableRenderer>();
         }
     }
 }

--- a/src/Markdig/Extensions/Tables/PipeTableExtension.cs
+++ b/src/Markdig/Extensions/Tables/PipeTableExtension.cs
@@ -5,6 +5,7 @@
 using Markdig.Extensions.Emoji;
 using Markdig.Parsers.Inlines;
 using Markdig.Renderers;
+using Markdig.Renderers.Normalize;
 
 namespace Markdig.Extensions.Tables;
 
@@ -51,6 +52,12 @@ public class PipeTableExtension : IMarkdownExtension
             if (!pipeline.InlineParsers.InsertBefore<EmojiParser>(pipeTableParser))
             {
                 pipeline.InlineParsers.InsertBefore<EmphasisInlineParser>(pipeTableParser);
+            }
+            
+            var normalizeRenderer = renderer as NormalizeRenderer;
+            if (normalizeRenderer != null)
+            {
+                normalizeRenderer.ObjectRenderers.AddIfNotAlready<NormalizeTableRenderer>();
             }
         }
     }


### PR DESCRIPTION
This PR attempts to complete the work started in
- #184

Which was part of 
- #155 

This PR adds support for PipeTables.  The existing work that was done in #184 was cherry-picked and only updated slightly to catch it up with all of the other changes since it was created.

The original PR was delayed because three of its included tests were failing. This update revalidates the same table-normalization work against the current tree with those same tests, which are now passing without any additional changes.  I was able to produce a similar problem that was described in the original PR's comments if I included two of the test cases' tables without a new line between them

```markdown
| Foo |
| --- |
| Hello World |
| Foo | Bar |
| --- | --- |
| Hello World | *World* |
```

will yield
```
| Foo |  |
| --- |
| Hello World |  |
| Foo | Bar |
| --- | --- |
| Hello World | *World* |
```

But that is expected, that is one table, where the first 2 rows only have one cell's worth of data, while the remaining three rows have two cells.

I did find one problems while experimenting with this, the original implementation would always include an extra new line after the table.  I fixed that and added a test to catch it `PipeTablesFollowedByText`.


> [!IMPORTANT]
> The scope of this PR is PipeTables tables, and as implemented it tries format all tables as PipeTables.  So it will try to - and normally fail to - render GridTables as PipeTables
> So input like this
> ```markdown
> +---------------+---------------+-------+
> | Product       | Category      | Price |
> +===============+===============+=======+
> | Laptop        | Electronics   | $999  |
> | Parts         | Components    |       |
> +---------------+---------------+-------+
> | Chair with    | Furniture     | $150  |
> | Table         |               |       |
> +---------------+---------------+-------+
> ```
> Will yield
> ```
> | Product | Category | Price |
> | --- | --- | --- |
> | Laptop
> Parts | Electronics
> Components | $999 |
> | Chair with
> Table | Furniture | $150 |
> ```
>
> I could exclude rendering tables if the Grid Extension is in use, but since it gets included with `UseAdvancedExtensions` I think that will result in this getting skipped more often than it needs to be.  Additionally without this change it gets rendered as follow which is not any better.
> ```
> ProductCategoryPriceLaptop
> PartsElectronics
> Components$999Chair with
> TableFurniture$150
> ```
